### PR TITLE
Added workaround for ibm_db2 issue

### DIFF
--- a/package.js
+++ b/package.js
@@ -60,6 +60,13 @@ function build(cfg) {
 
 function startPack() {
     console.log('start pack...');
+    /*
+     * Workaround for: https://github.com/ibmdb/node-ibm_db/issues/329
+     * This can be removed once the issue is resolved.
+     */
+    if(os.platform == 'darwin') {
+        exec('install_name_tool -change `pwd`/node_modules/ibm_db/installer/clidriver/lib/libdb2.dylib @loader_path/../../installer/clidriver/lib/libdb2.dylib node_modules/ibm_db/build/Release/odbc_bindings.node');
+    }
     build(electronCfg)
     .then(() => build(cfg))
     .then(() => del('release'))


### PR DESCRIPTION
Fixes the broken mac builds, which were being caused by: https://github.com/ibmdb/node-ibm_db/issues/329
This is a workaround, and can be removed once the issue is resolved on `node-ibm_db` side..