### PR TITLE
Remember selected panels and handle case when user hasn't logged in

### DIFF
--- a/app/components/Configuration.react.js
+++ b/app/components/Configuration.react.js
@@ -77,24 +77,15 @@ class Configuration extends Component {
             align: 'right',
             animate: false
         };
-        const loginMessage = this.state.username ?
-                             <div className="supportLinksContainer">
-                                 Logged in as "{this.state.username}" &nbsp;
-                                 <Link onClick={this.logOut} >
-                                     Log Out
-                                 </Link>
-                             </div>
-                             :
-                             <div>
-                                 <Link to="/login" >Log In</Link>
-                             </div>;
 
-        return (
+        return (isElectron() || this.state.username) ? (
             <div className="fullApp">
-                {loginMessage}
-                <Settings/>
+                <Settings username={this.state.username} logout={this.logOut}/>
             </div>
-
+        ): (
+            <div className="fullApp">
+                <Link to="/login" >Log In</Link>
+            </div>
         );
     }
 }

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -29,6 +29,7 @@ class Settings extends Component {
         this.renderSettingsForm = this.renderSettingsForm.bind(this);
         this.state = {
             editMode: true,
+            selectedPanel: {},
             urls: {
                 https: null,
                 http: null
@@ -310,7 +311,10 @@ class Settings extends Component {
 
                 <div className={'openTab'}>
 
-                    <Tabs defaultIndex={0}>
+                    <Tabs
+                        selectedIndex={this.state.selectedPanel[selectedTab] || 0}
+                        onSelect={panelIndex => this.setState({selectedPanel: {[selectedTab]: panelIndex}})}
+                    >
 
                         <TabList>
                             <Tab>Connection</Tab>

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -29,6 +29,7 @@ class Settings extends Component {
         this.renderSettingsForm = this.renderSettingsForm.bind(this);
         this.state = {
             editMode: true,
+            isLoggedIn: false,
             selectedPanel: {},
             urls: {
                 https: null,
@@ -42,6 +43,27 @@ class Settings extends Component {
             checkHTTPSEndpointInterval: null,
             getConnectorUrlsInterval: null
         };
+
+        const checkIfLoggedIn = () => {
+            return fetch(`/settings`, {
+                method: 'GET',
+                headers: {
+                    'Accept': 'application/json',
+                    'Content-Type': 'application/json'
+                }
+            }).then((res) => res.json().then((json) => {
+                return (res.status === 200 && json.USERS.length > 0);
+            })).catch((e) => {
+                return false;
+            }).then(isLoggedIn => {
+                this.setState({isLoggedIn});
+                if(!isLoggedIn) setTimeout(checkIfLoggedIn, 1000);
+            }).catch((e) => {
+                console.error(e);
+            });
+        };
+
+        checkIfLoggedIn();
     }
 
     componentDidMount() {
@@ -425,7 +447,7 @@ class Settings extends Component {
                                                 </Link>
                                             </div>
                                         </div>
-                                    ) : (
+                                    ) : (this.state.isLoggedIn) ? (
                                         <div>
                                             <p>
                                                 {`Plotly is automatically initializing a
@@ -438,6 +460,12 @@ class Settings extends Component {
                                                 </Link>
                                                 {`. It has been ${timeElapsed}. Check out the
                                                 FAQ while you wait! 📰`}
+                                            </p>
+                                        </div>
+                                    ): (
+                                        <div>
+                                            <p>
+                                                <a onClick={() => window.location.assign('/login')}>Log into Plotly</a>
                                             </p>
                                         </div>
                                     )

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -29,7 +29,6 @@ class Settings extends Component {
         this.renderSettingsForm = this.renderSettingsForm.bind(this);
         this.state = {
             editMode: true,
-            isLoggedIn: false,
             selectedPanel: {},
             urls: {
                 https: null,
@@ -43,27 +42,6 @@ class Settings extends Component {
             checkHTTPSEndpointInterval: null,
             getConnectorUrlsInterval: null
         };
-
-        const checkIfLoggedIn = () => {
-            return fetch(`/settings`, {
-                method: 'GET',
-                headers: {
-                    'Accept': 'application/json',
-                    'Content-Type': 'application/json'
-                }
-            }).then((res) => res.json().then((json) => {
-                return (res.status === 200 && json.USERS.length > 0);
-            })).catch((e) => {
-                return false;
-            }).then(isLoggedIn => {
-                this.setState({isLoggedIn});
-                if(!isLoggedIn) setTimeout(checkIfLoggedIn, 1000);
-            }).catch((e) => {
-                console.error(e);
-            });
-        };
-
-        checkIfLoggedIn();
     }
 
     componentDidMount() {
@@ -446,8 +424,13 @@ class Settings extends Component {
                                                     <strong><code>{connectorUrl}</code></strong>
                                                 </Link>
                                             </div>
+                                            <p>
+                                                {`Logged in as "${this.props.username}"`}
+                                                <br/>
+                                                <a onClick={this.props.logout}>Log Out</a>
+                                            </p>
                                         </div>
-                                    ) : (this.state.isLoggedIn) ? (
+                                    ) : (this.props.username) ? (
                                         <div>
                                             <p>
                                                 {`Plotly is automatically initializing a
@@ -461,11 +444,18 @@ class Settings extends Component {
                                                 {`. It has been ${timeElapsed}. Check out the
                                                 FAQ while you wait! 📰`}
                                             </p>
+                                            <p>
+                                                {`Logged in as "${this.props.username}"`}
+                                                <br/>
+                                                <a onClick={this.props.logout}>Log Out</a>
+                                            </p>
                                         </div>
                                     ): (
                                         <div>
                                             <p>
                                                 <a onClick={() => window.location.assign('/login')}>Log into Plotly</a>
+                                                <br/>
+                                                Please, login in order to connect your queries to your Plotly account.
                                             </p>
                                         </div>
                                     )

--- a/backend/main.development.js
+++ b/backend/main.development.js
@@ -39,6 +39,7 @@ app.on('ready', () => {
      * This allows us to send pass information to electron renderer from
      * inside the server.
      */
+    server.electronWindow = mainWindow;
     httpServer.electronWindow = mainWindow;
     httpsServer.electronWindow = mainWindow;
 


### PR DESCRIPTION
This PR implements:

* The selected panel for each connection is stored in the component state and new connections default to the Connection panel.

* If the users hasn't logged into Plotly, the Plot.ly panel shows a link to the login page.

