### PR TITLE
Add dependency on 'prop-types' library

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "pg-hstore": "^2.3.2",
     "plotly.js": "^1.30.0",
     "postcss": "^5.0.19",
+    "prop-types": "^15.6.0",
     "query-string": "^4.2.3",
     "ramda": "^0.21.0",
     "react": "^15.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7459,7 +7459,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8:
+prop-types@^15.0.0, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:


### PR DESCRIPTION
- Note: 'prop-types' was a transitive dependency and thus is
  being used in a couple of places already. This commit makes the dependency an ordinary project dependency since `PropTypes` are at the core of React apps
- Is related to fixing a lot of ESLint `react/prop-types` errors