### PR TITLE
test: add comment to connections.yaml

### DIFF
--- a/sample-storage/connections.yaml
+++ b/sample-storage/connections.yaml
@@ -1,3 +1,11 @@
+# Credentials to the test databases.
+#
+# - these credentials are made intentionally public
+#
+# - these test databases only contain sample data
+#
+# - their only purpose is testing falcon-sql-connector
+
 -
     dialect: postgres
     id: postgres-189ebfb4-e1b4-446c-9b83-b326875fa2d8


### PR DESCRIPTION
* Added comment to `connections.yaml` to describe that these credentials
  are made public intentionally only for the purpose of testing
  falcon-sql-connector.