### PR TITLE
Fix postgres PREVIEW_QUERY

### DIFF
--- a/app/actions/sessions.js
+++ b/app/actions/sessions.js
@@ -365,9 +365,10 @@ function PREVIEW_QUERY (dialect, table, database = '') {
         case DIALECTS.MYSQL:
         case DIALECTS.SQLITE:
         case DIALECTS.MARIADB:
-        case DIALECTS.POSTGRES:
         case DIALECTS.REDSHIFT:
             return `SELECT * FROM ${table} LIMIT 1000`;
+        case DIALECTS.POSTGRES:
+            return `SELECT * FROM "${table}" LIMIT 1000`;
         case DIALECTS.MSSQL:
             return 'SELECT TOP 1000 * FROM ' +
                 `${database}.dbo.${table}`;


### PR DESCRIPTION
If the postgres database contained tables whose names contained uppercase letters, then an error would appear in the UI and prevent the user from making further queries.

Example a table named Dogs would result in the error:
`relation "dogs" does not exist`