### PR TITLE
package.json: pin engines to major number only

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,11 +239,11 @@
     "yamljs": "^0.2.8"
   },
   "engines": {
-    "node": "6.11.1",
-    "yarn": "1.2.1"
+    "node": "6",
+    "yarn": "1"
   },
   "devEngines": {
-    "node": "6.11.1",
-    "yarn": "1.2.1"
+    "node": "6",
+    "yarn": "1"
   }
 }


### PR DESCRIPTION
I find inconvenient to pin to a single node version.

@chriddyp Shall we pin only to the major number?