### PR TITLE
test: increase refresh interval in QueryScheduler

### DIFF
--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -276,7 +276,7 @@ describe('QueryScheduler', function() {
             }));
         }
 
-        const refreshInterval = 30; // seconds
+        const refreshInterval = 60; // seconds
         this.timeout(10 * refreshInterval * 1000);
 
         /*


### PR DESCRIPTION
* Increase refresh interval from 30 to 60 seconds.

* The spec 'QueryScheduler queries a database and updates a plotly grid
  on an interval' fails if PlotlyAPIRequest takes longer than the
  refresh interval to respond.

Closes #262