### PR TITLE
travis: zip only the mac installer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 script:
   - yarn run build
   - yarn run pack
-  - zip -r release.zip release -q
+  - zip release.zip release/Falcon* release/*.yml
 
 before_cache:
   - rm -rf $HOME/.cache/electron-builder/wine


### PR DESCRIPTION
* Reduced artifact file size from 280MB to 94MB