### PR TITLE
electron-builder: disable asar

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "build": {
     "appId": "org.plotly.connector",
+    "asar": false,
     "productName": "Falcon SQL Client",
     "files": [
       "app",


### PR DESCRIPTION
* Otherwise, windows app will fail to load ibm_db native module.