### PR TITLE
dockerfile: add script `yarn run start-dockerfile`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,13 @@ The database connector runs as a server by default as part of [Plotly On-Premise
 
 ## Run as a docker image
 
+Build and run the docker image:
+```
+$ yarn run start-dockerfile
+```
+
+The web app will be accessible in your browser at `http://localhost:9494`.
+
 See the [Dockerfile](https://github.com/plotly/falcon-sql-client/blob/master/Dockerfile) for more information.
 
 ## Developing

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "package-all": "yarn run package -- --all",
     "rebuild-and-e2e": "yarn run build && yarn run test-e2e",
     "start": "cross-env NODE_ENV=production electron ./",
+    "start-dockerfile": "docker build -t falcon-sql-client:local . && docker run -ti --rm -p 9494:9494 -e PLOTLY_CONNECTOR_AUTH_ENABLED=false falcon-sql-client:local",
     "start-headless": "cross-env NODE_ENV=production node ./dist/headless-bundle.js",
     "start-hot": "cross-env HOT=1 NODE_ENV=development electron --disable-http-cache -r babel-register ./backend/main.development",
     "watch-headless": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.headless.js --profile --colors --watch",


### PR DESCRIPTION
* It builds a new image `falcon-sql-client:local` and runs it with
  PLOTLY_CONNECTOR_AUTH_ENABLED=false .

* Updated documentation in `CONTRIBUTING.md`.