### PR TITLE
add scripts to build and run Dockerfile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,14 @@ The database connector runs as a server by default as part of [Plotly On-Premise
 
 ## Run as a docker image
 
+Build and run the docker image:
+```
+$ yarn run docker:falcon:build
+$ PLOTLY_CONNECTOR_AUTH_ENABLED=false yarn run docker:falcon:start
+```
+
+The web app will be accessible in your browser at `http://localhost:9494`.
+
 See the [Dockerfile](https://github.com/plotly/falcon-sql-client/blob/master/Dockerfile) for more information.
 
 ## Developing

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "build-web": "cross-env NODE_ENV=production node -r babel-register ./node_modules/webpack/bin/webpack --config webpack.config.web.js --profile --colors",
     "docker:db2:build": "docker build test/docker/ibmdb2/ -t pdc-db2 --build-arg LICENSE=accept --build-arg DB2INST1_PASSWORD=${DB2INST1_PASSWORD} --build-arg DB2USER1_PASSWORD=${DB2USER1_PASSWORD} --no-cache",
     "docker:db2:start": "docker run --rm -ti -p 50000:50000 pdc-db2",
+    "docker:falcon:build": "docker build -t falcon-sql-client:local .",
+    "docker:falcon:start": "docker run -ti --rm -p 9494:9494 -e PLOTLY_CONNECTOR_AUTH_ENABLED=$PLOTLY_CONNECTOR_AUTH_ENABLED -e PLOTLY_CONNECTOR_ALLOWED_USERS=$PLOTLY_CONNECTOR_ALLOWED_USERS falcon-sql-client:local",
     "rebuild:modules:electron": "cross-env FSEVENTS_BUILD_FROM_SOURCE=true node scripts/rebuild-modules.js --electron",
     "rebuild:modules:node": "cross-env FSEVENTS_BUILD_FROM_SOURCE=true node scripts/rebuild-modules.js",
     "fix:module:ibmdb": "node scripts/fix-module-ibmdb.js",


### PR DESCRIPTION
* `yarn run docker:falcon:build` builds the Dockerfile and tags the image
  as `falcon-sql-client:local`.

* `PLOTLY_CONNECTOR_AUTH_ENABLED=false yarn run docker:falcon:start`
  runs `yarn run start-headless` inside a Docker container.

* Updated documentation in `CONTRIBUTING.md`.