### PR TITLE
onprem: remove version from app title

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -9,11 +9,13 @@ import {build, version} from '../package.json';
 import Login from './components/Login.react';
 import Configuration from './components/Configuration.react';
 import Status from './components/Oauth.react';
-import {homeUrl} from './utils/utils';
+import {homeUrl, isOnPrem} from './utils/utils';
 
 const store = configureStore();
 
-window.document.title = `${build.productName} v${version}`;
+window.document.title = isOnPrem() ?
+    `${build.productName}` :
+    `${build.productName} v${version}`;
 
 render(
     <Provider store={store}>


### PR DESCRIPTION
I can now see that updating `package.json` in the onprem branch is going to waste our time.

Let's just remove the version when falcon runs onprem.

I've tested this commit locally. Could any of you test it on prem, please?

- [x] test desktop app
- [x] test onprem app

cc/ @scjody @tarzzz @chriddyp 


Closes https://github.com/plotly/streambed/issues/10450