### PR TITLE
app: set preview query for non-sql connectors

### DIFF
--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -222,7 +222,7 @@ export function PREVIEW_QUERY (dialect, table, database = '') {
                 }
             });
         default:
-            throw new Error(`Dialect ${dialect} is not one of the DIALECTS`);
+            return '';
     }
 }
 


### PR DESCRIPTION
* Do not throw if preview query hasn't been defined for a connector.

Closes https://github.com/plotly/streambed/issues/10453