### PR TITLE
pack: disable asar only in windows package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   },
   "build": {
     "appId": "org.plotly.connector",
-    "asar": false,
     "productName": "Falcon SQL Client",
     "files": [
       "app",
@@ -58,7 +57,6 @@
     ],
     "linux": {
       "category": "Database",
-      "compression": "store",
       "desktop": {
         "Comment": "Free, open-source SQL client for Windows, Mac and Linux",
         "Exec": "falcon-sql-client",
@@ -84,6 +82,7 @@
       "icon": "app/icons/app.icns"
     },
     "win": {
+      "asar": false,
       "target": [
         "nsis"
       ],


### PR DESCRIPTION
* I had to disable asar in the package for Windows, because it breaks
  ibm_db.

* Re-enable compression in packages for Linux