### PR TITLE
Check in fix for ES behind Nginx

### DIFF
--- a/backend/persistent/datastores/Elasticsearch.js
+++ b/backend/persistent/datastores/Elasticsearch.js
@@ -6,7 +6,12 @@ const MAX_RESULTS_SIZE = 10 * 1000;
 
 function request(relativeUrl, connection, {body, method, queryStringParams = ''}) {
     const {host, port, username, password} = connection;
-    const url = `${host}:${port}/${relativeUrl}?format=json${queryStringParams}`;
+    let url;
+    if (typeof port !== 'undefined' && port !== '') {
+        url = `${host}:${port}/${relativeUrl}?format=json${queryStringParams}`;
+    } else {
+        url = `${host}/${relativeUrl}?format=json${queryStringParams}`;
+    }
     const headers = {
         'Accept': 'application/json',
         'Content-Type': 'application/json'


### PR DESCRIPTION
This is a small fix for #343 to handle the situation where Elastic Search is behind NGINX.  This is a common situation on smaller Elastic Search DBs that do not want to use X-Pack to handle authentication.  When the port is not defined it will exclude the port from the url and attempt to connect as is.