### PR TITLE
app: fix initial preview query

### DIFF
--- a/app/actions/sessions.js
+++ b/app/actions/sessions.js
@@ -208,9 +208,9 @@ export function getApacheDrillS3Keys(connectionId) {
     );
 }
 
-export function previewTable (connectionId, dialect, table, database) {
+export function previewTable(connectionId, connectionObject, table, elasticsearchIndex) {
     const body = {
-        query: PREVIEW_QUERY(dialect, table, database)
+        query: PREVIEW_QUERY(connectionObject, table, elasticsearchIndex)
     };
     return apiThunk(
         `connections/${connectionId}/query`,

--- a/app/components/Settings/Preview/Preview.react.js
+++ b/app/components/Settings/Preview/Preview.react.js
@@ -294,7 +294,7 @@ class Preview extends Component {
 
         const dialect = connectionObject.dialect;
         const showEditor = propOr(true, 'showEditor')(preview);
-        const code = propOr(PREVIEW_QUERY(dialect, selectedTable), 'code')(preview);
+        const code = propOr(PREVIEW_QUERY(connectionObject, selectedTable), 'code')(preview);
         propOr('', 'error')(preview);
 
         // Surpressing ESLint cause restricting line length would harm JSX readability

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -520,7 +520,7 @@ function mapStateToProps(state) {
     const preview = previews[selectedConnectionId] || {};
     const connection = connections[selectedTab];
     if (connection && !hasIn('code', preview)) {
-        preview.code = PREVIEW_QUERY(connection.dialect, selectedTable);
+        preview.code = PREVIEW_QUERY(connection, selectedTable);
     }
 
     return {
@@ -604,9 +604,9 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
     function boundPreviewTables() {
         return dispatch(Actions.previewTable(
             selectedConnectionId,
-            connectionObject.dialect,
+            connectionObject,
             selectedTable,
-            connectionObject.database || selectedIndex
+            selectedIndex
         ));
     }
     function boundUpdatePreview(previewUpdateObject) {

--- a/app/constants/constants.js
+++ b/app/constants/constants.js
@@ -214,8 +214,8 @@ export const LOGOS = {
     [DIALECTS.DATA_WORLD]: 'images/dataworld-logo.png'
 };
 
-export function PREVIEW_QUERY (dialect, table, database = '') {
-    switch (dialect) {
+export function PREVIEW_QUERY(connection, table, elasticsearchIndex) {
+    switch (connection.dialect) {
         case DIALECTS.IBM_DB2:
             return `SELECT * FROM ${table} FETCH FIRST 1000 ROWS ONLY`;
         case DIALECTS.APACHE_IMPALA:
@@ -228,11 +228,10 @@ export function PREVIEW_QUERY (dialect, table, database = '') {
         case DIALECTS.REDSHIFT:
             return `SELECT * FROM ${table} LIMIT 1000`;
         case DIALECTS.MSSQL:
-            return 'SELECT TOP 1000 * FROM ' +
-                `${database}.dbo.${table}`;
+            return `SELECT TOP 1000 * FROM ${connection.database}.dbo.${table}`;
         case DIALECTS.ELASTICSEARCH:
             return JSON.stringify({
-                index: database || '_all',
+                index: elasticsearchIndex || '_all',
                 type: table || '_all',
                 body: {
                     query: { 'match_all': {} },


### PR DESCRIPTION
* Fix invocation of `PREVIEW_QUERY` from `Settings.react.js` and
  `Preview.react.js`. This fixes the initial preview query that depend
  on the database name (e.g. MSSql).

---

@tarzzz Would you review this PR?

cc/ @shannonlal I thought you may want to have a look at this PR, since it touches code that affects the ElasticSearch connector.