### PR TITLE
dataworld: improve error message

### DIFF
--- a/app/components/Settings/Preview/Preview.react.js
+++ b/app/components/Settings/Preview/Preview.react.js
@@ -66,14 +66,23 @@ class Preview extends Component {
         let rows = [];
         let columnNames = [];
         let isLoading = false;
-        let errorMsg = '';
         let successMsg = '';
+
+        let errorMsg = '';
+        function setErrorMsg(error) {
+            try {
+                errorMsg = error.content.error.message;
+            } catch (_) {
+                errorMsg = JSON.stringify(error);
+            }
+            errorMsg = String(errorMsg).trim();
+        }
 
         if (isEmpty(previewTableRequest) || previewTableRequest.status === 'loading') {
             isLoading = true;
         }
         else if (previewTableRequest.status !== 200) {
-            errorMsg = JSON.stringify(previewTableRequest);
+            setErrorMsg(previewTableRequest);
         }
         else if (isEmpty(queryRequest)) {
             rows = previewTableRequest.content.rows;
@@ -104,7 +113,7 @@ class Preview extends Component {
                 columnNames = previewTableRequest.content.columnnames;
                 successMsg = `${rows.length} rows retrieved`;
             }
-            errorMsg = JSON.stringify(queryRequest);
+            setErrorMsg(queryRequest);
         }
         else {
             // User's query worked
@@ -348,7 +357,7 @@ class Preview extends Component {
 
                 {errorMsg &&
                     <div className="errorStatus">
-                        <p>{`ERROR ${errorMsg}`}</p>
+                        <pre>{`ERROR: ${errorMsg}`}</pre>
                     </div>
                 }
 

--- a/backend/persistent/datastores/dataworld.js
+++ b/backend/persistent/datastores/dataworld.js
@@ -90,7 +90,13 @@ export function query(queryString, connection) {
   .then(res => {
     if (res.status !== 200) {
       return res.text().then(body => {
-        throw new Error(body);
+        let error;
+        try {
+          error = new Error(JSON.parse(body).message);
+        } catch (_) {
+          error = new Error(body);
+        }
+        throw error;
       });
     }
     return res.json();

--- a/backend/persistent/datastores/dataworld.js
+++ b/backend/persistent/datastores/dataworld.js
@@ -88,6 +88,11 @@ export function query(queryString, connection) {
     body: params
   })
   .then(res => {
+    if (res.status !== 200) {
+      return res.text().then(body => {
+        throw new Error(body);
+      });
+    }
     return res.json();
   })
   .then(json => {

--- a/static/css/Preview.css
+++ b/static/css/Preview.css
@@ -36,17 +36,17 @@ th, td {
     z-index: 10;
 }
 
-.errorStatus p {
+.errorStatus pre {
     padding: 20px;
     margin: 0 0 20px 0;
     background: none;
     border: none;
     color: rgb(211, 96, 70);
     border-bottom: 1px solid #ebf0f8;
-    font-size: 14px;
+    font-size: 12px;
     font-family: 'Ubuntu Mono';
-    overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-x: auto;
+    overflow-y: auto;
     max-height: 150px;
 }
 


### PR DESCRIPTION
@kndungu @rflprr Since you are familiar with the code, would you like to review this PR?

* data.world: send error message of failed queries.

* Preview: repect line breaks in error messages and use mono-space font.

Closes #389 

![screenshot from 2018-03-02 17-49-55](https://user-images.githubusercontent.com/6199391/36913999-aa70940a-1e43-11e8-86e9-111307c84cdc.png)
