### PR TITLE
circle: pin to node@6.13.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:6-browsers
+      - image: circleci/node:6.13.0-browsers
       - image: quay.io/plotly/falcon-test-spark
       - image: quay.io/plotly/falcon-test-db2
     environment:


### PR DESCRIPTION
* Tests in latest docker image circleci/node:6.13.1-browsers fail with
  error:

  /home/circleci/falcon/node_modules/electron/dist/electron:
  error while loading shared libraries:
  libgconf-2.so.4:
  cannot open shared object file:
  No such file or directory