### PR TITLE
Settings: hide chart & show code editor if needed

### DIFF
--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -289,7 +289,14 @@ class Settings extends Component {
                     connections={connections}
                     selectedTab={selectedTab}
                     newTab={newTab}
-                    setTab={setTab}
+                    setTab={tabId => {
+                        setTab(tabId);
+                        updatePreview({
+                            showChart: false,
+                            showEditor: true,
+                            size: 200
+                        });
+                    }}
                     deleteTab={deleteTab}
                 />
 


### PR DESCRIPTION
* This commit is a workaround that fixes the breakage of the Query panel
  triggered when switching back to a connection where the ChartEditor
  was visible.

* It works around the breakage by hiding the ChartEditor and showing the
  CodeEditor whenever the user clicks on a connection tab.