### PR TITLE
Do not hide the code editor automatically

### DIFF
--- a/app/components/Settings/Preview/Preview.react.js
+++ b/app/components/Settings/Preview/Preview.react.js
@@ -389,15 +389,17 @@ class Preview extends Component {
                                                 // If Chart Editor selected and Schemas Tree visible,
                                                 // then save size in lastSize before hiding
                                                 this.props.updatePreview({
+                                                    // uncomment to hide sql editor
+                                                    // showEditor: false,
                                                     showChart: true,
-                                                    showEditor: false,
                                                     lastSize: size,
                                                     size: minSize
                                                 });
                                             } else {
                                                 this.props.updatePreview({
-                                                    showChart: true,
-                                                    showEditor: false
+                                                    // uncomment to hide sql editor
+                                                    // showEditor: false,
+                                                    showChart: true
                                                 });
                                             }
                                         } else {
@@ -405,14 +407,16 @@ class Preview extends Component {
                                                 // If Chart Editor not selected and Schemas Tree was hidden,
                                                 // then restore the last size
                                                 this.props.updatePreview({
+                                                    // uncomment to show sql editor
+                                                    // showEditor: true,
                                                     showChart: false,
-                                                    showEditor: true,
                                                     size: lastSize
                                                 });
                                             } else {
                                                 this.props.updatePreview({
-                                                    showChart: false,
-                                                    showEditor: true
+                                                    // uncomment to show sql editor
+                                                    // showEditor: true,
+                                                    showChart: false
                                                 });
                                             }
                                         }

--- a/app/components/Settings/Preview/code-editor.css
+++ b/app/components/Settings/Preview/code-editor.css
@@ -4,6 +4,7 @@
     font-size: 14px;
     height: 140px;
     margin-bottom: 20px;
+    width: 740px;
 }
 
 .CodeMirror-gutters {

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -290,12 +290,12 @@ class Settings extends Component {
                     selectedTab={selectedTab}
                     newTab={newTab}
                     setTab={tabId => {
-                        setTab(tabId);
                         updatePreview({
                             showChart: false,
                             showEditor: true,
                             size: 200
                         });
+                        setTab(tabId);
                     }}
                     deleteTab={deleteTab}
                 />
@@ -304,7 +304,14 @@ class Settings extends Component {
 
                     <Tabs
                         selectedIndex={this.state.selectedPanel[selectedTab] || 0}
-                        onSelect={panelIndex => this.setState({selectedPanel: {[selectedTab]: panelIndex}})}
+                        onSelect={(panelIndex) => {
+                            updatePreview({
+                                showChart: false,
+                                showEditor: true,
+                                size: 200
+                            });
+                            this.setState({selectedPanel: {[selectedTab]: panelIndex}});
+                        }}
                     >
 
                         <TabList>


### PR DESCRIPTION

![peek 2018-05-28 17-55](https://user-images.githubusercontent.com/6199391/40623751-5b7fb56e-62a0-11e8-8015-e5256d6e1241.gif)


cc/ @jackparmer 

Closes #443 

---

This PR also includes two bug fixes:
* fixes hidden run button (when auto-resize wouldn't be trigerred)
* ensures the schemas panel is shown when coming back to the query panel.