### PR TITLE
disable nodeintegration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ RUN yarn run heroku-postbuild
 
 ENV PLOTLY_CONNECTOR_PORT 9494
 EXPOSE 9494
-ENTRYPOINT yarn run build-web && yarn run start-headless
+ENTRYPOINT yarn run start-headless

--- a/app/components/Configuration.react.js
+++ b/app/components/Configuration.react.js
@@ -2,20 +2,21 @@ import cookie from 'react-cookies';
 import React, { Component, PropTypes } from 'react';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
-import Settings from './Settings/Settings.react';
-import {isElectron} from '../utils/utils';
-import * as SessionsActions from '../actions/sessions';
-import Login from './Login.react';
+
+import Login from './Login.react.js';
+import * as SessionsActions from '../actions/sessions.js';
+import Settings from './Settings/Settings.react.js';
+import {isElectron} from '../utils/utils.js';
 
 
 class Configuration extends Component {
     constructor(props) {
         super(props);
         this.state = {
+            authEnabled: (cookie.load('db-connector-auth-enabled') === 'true'),
+            clientId: cookie.load('db-connector-client-id'),
             isMenuOpen: false,
-            username: cookie.load('db-connector-user'),
-            /* global PLOTLY_ENV */
-            authDisabled: !PLOTLY_ENV.AUTH_ENABLED
+            username: cookie.load('db-connector-user')
         };
         this.toggle = this.toggle.bind(this);
         this.close = this.close.bind(this);
@@ -44,26 +45,24 @@ class Configuration extends Component {
     }
 
     logOut() {
+        /*
+         * Delete all the cookies and reset user state. This does not kill
+         * any running connections, but user will not be able to access them
+         * without logging in again.
+         */
+        cookie.remove('db-connector-user');
+        cookie.remove('plotly-auth-token');
+        cookie.remove('db-connector-auth-token');
+        this.setState({ username: ''});
 
-      /*
-       * Delete all the cookies and reset user state. This does not kill
-       * any running connections, but user will not be able to access them
-       * without logging in again.
-       */
-      cookie.remove('db-connector-user');
-      cookie.remove('plotly-auth-token');
-      cookie.remove('db-connector-auth-token');
-      cookie.remove('db-connector-auth-disabled');
-      this.setState({ username: ''});
-
-      // reload page when running in browser:
-      if (!isElectron()) {
-          window.location.reload();
-      }
+        // reload page when running in browser:
+        if (!isElectron()) {
+            window.location.reload();
+        }
     }
 
     render() {
-        return (isElectron() || this.state.authDisabled || this.state.username) ? (
+        return (isElectron() || !this.state.authEnabled || this.state.username) ? (
             <div className="fullApp">
                 <Settings username={this.state.username} logout={this.logOut}/>
             </div>

--- a/app/components/Configuration.react.js
+++ b/app/components/Configuration.react.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux';
 import Login from './Login.react.js';
 import * as SessionsActions from '../actions/sessions.js';
 import Settings from './Settings/Settings.react.js';
-import {isElectron} from '../utils/utils.js';
+import {isElectron, setUsernameListener} from '../utils/utils.js';
 
 
 class Configuration extends Component {
@@ -28,12 +28,9 @@ class Configuration extends Component {
          * In the browser, the username is set with a cookie but in electron
          * this is set using electron's ipcRenderer.
          */
-        if (isElectron()) {
-            window.require('electron').ipcRenderer.once('username',
-                (event, message) => {
-                    this.setState({username: message});
-                });
-        }
+        setUsernameListener((event, message) => {
+            this.setState({username: message});}
+        );
     }
 
     toggle() {

--- a/app/components/Link.react.js
+++ b/app/components/Link.react.js
@@ -1,31 +1,5 @@
-import R from 'ramda';
 import React from 'react';
-import PropTypes from 'prop-types';
-import {dynamicRequireElectron} from '../utils/utils';
-
-
-let shell;
-try {
-    shell = dynamicRequireElectron().shell;
-} catch (e) {
-    shell = null;
-}
 
 export function Link(props) {
-    const {href} = props;
-    if (shell) {
-        return (
-            <span
-                className={`${props.className}`}
-                onClick={() => {shell.openExternal(href);}}
-                {...R.omit(['className'], props)}
-            />
-        );
-    }
-    return <a href={href} target="_blank" {...props}/>;
+    return <a target="_blank" rel="noopener" {...props}/>;
 }
-
-Link.propTypes = {
-    href: PropTypes.string,
-    className: PropTypes.string
-};

--- a/app/components/Login.react.js
+++ b/app/components/Login.react.js
@@ -20,7 +20,6 @@ const CLOUD = 'cloud';
 const ONPREM = 'onprem';
 
 window.document.title = `${build.productName} v${version}`;
-let usernameLogged = '';
 
 class Login extends Component {
     constructor(props) {
@@ -35,6 +34,11 @@ class Login extends Component {
         this.buildOauthUrl = this.buildOauthUrl.bind(this);
         this.oauthPopUp = this.oauthPopUp.bind(this);
         this.logIn = this.logIn.bind(this);
+
+        // the web app:
+        // - sets this property to the popup window opened for authorization
+        // - and triggers a reload when `this.popup.closed` becomes true
+        this.popup = null;
     }
 
     componentDidMount() {
@@ -46,8 +50,7 @@ class Login extends Component {
          * to check for authentication.
          */
         setInterval(() => {
-            usernameLogged = cookie.load('db-connector-user');
-            if (usernameLogged) {
+            if (this.popup && this.popup.closed) {
                 if (serverType === ONPREM) {
                     this.setState({
                         status: 'authorized',
@@ -135,7 +138,7 @@ class Login extends Component {
         const left = ((width / 2) - (w / 2)) + dualScreenLeft;
         const top = ((height / 2) - (h / 2)) + dualScreenTop;
 
-        window.open(url, title, `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`);
+        this.popup = window.open(url, title, `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`);
     }
 
     logIn () {

--- a/app/components/Login.react.js
+++ b/app/components/Login.react.js
@@ -4,7 +4,6 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {
     baseUrl,
-    dynamicRequireElectron,
     homeUrl,
     isOnPrem,
     plotlyUrl
@@ -138,21 +137,11 @@ class Login extends Component {
     }
 
     oauthPopUp() {
-        try {
-            const electron = dynamicRequireElectron();
-            const oauthUrl = this.buildOauthUrl();
-            electron.shell.openExternal(oauthUrl);
-        } catch (e) {
-            // eslint-disable-next-line no-console
-            console.log('Unable to openExternal, opening a popupWindow instead:');
-            // eslint-disable-next-line no-console
-            console.log(e);
-            const popupWindow = PopupCenter(
-                this.buildOauthUrl(), 'Authorization', '500', '500'
-            );
-            if (window.focus) {
-                popupWindow.focus();
-            }
+        const popupWindow = PopupCenter(
+            this.buildOauthUrl(), 'Authorization', '500', '500'
+        );
+        if (window.focus) {
+            popupWindow.focus();
         }
     }
 

--- a/app/components/Login.react.js
+++ b/app/components/Login.react.js
@@ -22,33 +22,11 @@ const ONPREM = 'onprem';
 window.document.title = `${build.productName} v${version}`;
 let usernameLogged = '';
 
-// http://stackoverflow.com/questions/4068373/center-a-popup-window-on-screen
-const PopupCenter = (url, title, w, h) => {
-    // Fixes dual-screen position
-    const dualScreenLeft = 'screenLeft' in window ? window.screenLeft : screen.left;
-    const dualScreenTop = 'screenTop' in window ? window.screenTop : screen.top;
-
-    const width = window.innerWidth
-        ? window.innerWidth
-        : document.documentElement.clientWidth
-            ? document.documentElement.clientWidth
-            : screen.width;
-    const height = window.innerHeight
-        ? window.innerHeight
-        : document.documentElement.clientHeight
-            ? document.documentElement.clientHeight
-            : screen.height;
-
-    const left = ((width / 2) - (w / 2)) + dualScreenLeft;
-    const top = ((height / 2) - (h / 2)) + dualScreenTop;
-    const popupWindow = window.open(url, title, `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`);
-    return popupWindow;
-};
-
 class Login extends Component {
     constructor(props) {
         super(props);
         this.state = {
+            clientId: cookie.load('db-connector-client-id'),
             domain: (isOnPrem() ? plotlyUrl() : 'https://plot.ly'),
             statusMessage: '',
             serverType: CLOUD,
@@ -100,7 +78,6 @@ class Login extends Component {
     }
 
     saveDomainToSettings() {
-
         const {domain} = this.state;
         let PLOTLY_API_SSL_ENABLED = true;
         let PLOTLY_API_DOMAIN = '';
@@ -124,25 +101,41 @@ class Login extends Component {
 
     }
     buildOauthUrl() {
-        const {domain} = this.state;
-        /* global PLOTLY_ENV */
-        const oauthClientId = PLOTLY_ENV.OAUTH2_CLIENT_ID;
-
+        const {clientId, domain} = this.state;
         const redirect_uri = baseUrlWrapped;
         return (
             `${domain}/o/authorize/?response_type=token&` +
-            `client_id=${oauthClientId}&` +
+            `client_id=${clientId}&` +
             `redirect_uri=${redirect_uri}/oauth2/callback`
         );
     }
 
     oauthPopUp() {
-        const popupWindow = PopupCenter(
-            this.buildOauthUrl(), 'Authorization', '500', '500'
-        );
-        if (window.focus) {
-            popupWindow.focus();
-        }
+        // http://stackoverflow.com/questions/4068373/center-a-popup-window-on-screen
+        const url = this.buildOauthUrl();
+        const title = 'Authorization';
+        const w = '600';
+        const h = '600';
+
+        // Fixes dual-screen position
+        const dualScreenLeft = 'screenLeft' in window ? window.screenLeft : screen.left;
+        const dualScreenTop = 'screenTop' in window ? window.screenTop : screen.top;
+
+        const width = window.innerWidth
+            ? window.innerWidth
+            : document.documentElement.clientWidth
+                ? document.documentElement.clientWidth
+                : screen.width;
+        const height = window.innerHeight
+            ? window.innerHeight
+            : document.documentElement.clientHeight
+                ? document.documentElement.clientHeight
+                : screen.height;
+
+        const left = ((width / 2) - (w / 2)) + dualScreenLeft;
+        const top = ((height / 2) - (h / 2)) + dualScreenTop;
+
+        window.open(url, title, `scrollbars=yes, width=${w}, height=${h}, top=${top}, left=${left}`);
     }
 
     logIn () {

--- a/app/components/Settings/Preview/Preview.react.js
+++ b/app/components/Settings/Preview/Preview.react.js
@@ -171,7 +171,6 @@ class Preview extends Component {
     }
 
     fetchDatacache(payload, type) {
-
         const {username} = this.props;
         const payloadJSON = JSON.stringify({
             payload: payload, type: type, requestor: username});
@@ -187,7 +186,8 @@ class Preview extends Component {
         }).then(resp => {
             return resp.json();
         }).then(data => {
-            const plotlyLinks = this.state.plotlyLinks;
+            const {plotlyLinks} = this.state;
+
             let link;
 
             if (!('error' in data)) {
@@ -458,19 +458,6 @@ class Preview extends Component {
                                             <div style={{margin: '20px 0'}}>
                                                 <button
                                                     className="btn btn-outline"
-                                                    onClick={() => this.fetchDatacache(this.getCSVString(), 'grid')}
-                                                >
-                                                    Send CSV to Chart Studio
-                                                </button>
-                                                {!isOnPrem() &&
-                                                <button
-                                                    className="btn btn-outline"
-                                                    onClick={() => this.fetchDatacache(this.getCSVString(), 'csv')}
-                                                >
-                                                    Download CSV
-                                                </button>}
-                                                <button
-                                                    className="btn btn-outline"
                                                     onClick={() => this.fetchDatacache(
                                                         JSON.stringify(this.state.plotlyJSON),
                                                         'plot'
@@ -478,6 +465,21 @@ class Preview extends Component {
                                                 >
                                                     Send chart to Chart Studio
                                                 </button>
+                                                <button
+                                                    className="btn btn-outline"
+                                                    onClick={() => this.fetchDatacache(this.getCSVString(), 'grid')}
+                                                >
+                                                    Send CSV to Chart Studio
+                                                </button>
+                                                {!isOnPrem() &&
+                                                <button
+                                                    className="btn btn-outline"
+                                                    onClick={() => window.open(
+                                                        `data:text/csv;base64,${Buffer.from(this.getCSVString()).toString('base64')}`
+                                                    )}
+                                                >
+                                                    Download CSV
+                                                </button>}
                                             </div>
                                             <div style={{width: 650, height: 200, border: '1px solid #dfe8f3',
                                                 fontFamily: '\'Ubuntu Mono\', courier, monospace', paddingTop: 10,
@@ -488,12 +490,6 @@ class Preview extends Component {
                                                         {link.type === 'grid' &&
                                                             <div>
                                                                 <div style={{color: '#00cc96'}}>🎉  Link to your CSV on Chart Studio ⬇️</div>
-                                                                <Link href={link.url} target="_blank" className="externalLink">{link.url}</Link>
-                                                            </div>
-                                                        }
-                                                        {link.type === 'csv' &&
-                                                            <div>
-                                                                <div style={{color: '#00cc96'}}>💾  Your CSV has been saved ⬇️</div>
                                                                 <Link href={link.url} target="_blank" className="externalLink">{link.url}</Link>
                                                             </div>
                                                         }

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -60,10 +60,14 @@ class Settings extends Component {
 
         this.intervals.checkHTTPSEndpointInterval = setInterval(() => {
             if (this.state.urls.https) {
-                fetch(this.state.urls.https).then(() => {
+                fetch(this.state.urls.https)
+                .then(() => {
                     this.setState({httpsServerIsOK: true});
                     clearInterval(this.intervals.checkHTTPSEndpointInterval);
                     clearInterval(this.intervals.timeElapsedInterval);
+                })
+                .catch(() => {
+                    // silence fetch errors
                 });
             }
         }, 5 * 1000);

--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -251,6 +251,7 @@ class Settings extends Component {
             apacheDrillStorageRequest,
             apacheDrillS3KeysRequest,
             connections,
+            connectRequest,
             deleteTab,
             elasticsearchMappingsRequest,
             getSqlSchema,
@@ -287,6 +288,11 @@ class Settings extends Component {
 
         const dialect = connections[selectedTab].dialect;
 
+        const queryPanelDisabled = (
+            connectRequest.status !== 200 ||
+            (!selectedTable && contains(dialect, SQL_DIALECTS_USING_EDITOR))
+        );
+
         return (
             <div>
                 <ConnectionTabs
@@ -320,11 +326,7 @@ class Settings extends Component {
 
                         <TabList>
                             <Tab>Connection</Tab>
-                            {this.props.connectRequest.status === 200 && selectedTable ? (
-                                <Tab>Query</Tab>
-                            ) : (
-                                <Tab disabled={true}>Query</Tab>
-                            )}
+                            <Tab disabled={queryPanelDisabled}>Query</Tab>
                             {isOnPrem() || <Tab
                                 className="test-ssl-tab react-tabs__tab"
                             >
@@ -339,7 +341,11 @@ class Settings extends Component {
                         </TabPanel>
 
                         <TabPanel className={['tab-panel-query', 'react-tabs__tab-panel']}>
-                            {this.props.connectRequest.status === 200 && selectedTable ? (
+                            {queryPanelDisabled ? (
+                                <div className="big-whitespace-tab">
+                                    <p>Please connect to a data store in the Connection tab first.</p>
+                                </div>
+                            ) : (
                                 <Preview
                                     username={username}
 
@@ -369,10 +375,6 @@ class Settings extends Component {
                                     previewTableRequest={previewTableRequest || {}}
                                     tablesRequest={tablesRequest}
                                 />
-                            ) : (
-                                <div className="big-whitespace-tab">
-                                    <p>Please connect to a data store in the Connection tab first.</p>
-                                </div>
                             )}
                         </TabPanel>
 

--- a/app/components/Settings/UserConnections/UserConnections.react.js
+++ b/app/components/Settings/UserConnections/UserConnections.react.js
@@ -5,21 +5,12 @@ import Filedrop from './filedrop.jsx';
 import {contains} from 'ramda';
 
 import {CONNECTION_CONFIG, SAMPLE_DBS} from '../../../constants/constants';
-import {dynamicRequireElectron} from '../../../utils/utils';
-
-let dialog;
-try {
-    dialog = dynamicRequireElectron().remote.dialog;
-} catch (e) {
-    dialog = null;
-}
+import {showOpenDialog} from '../../../utils/utils';
 
 /*
  *  Displays and alters user inputs for `configuration`
  *  username, password, and local port number.
 */
-
-
 export default class UserConnections extends Component {
     constructor(props) {
         super(props);
@@ -47,7 +38,7 @@ export default class UserConnections extends Component {
     getStorageOnClick(setting) {
         // sqlite requires a path
         return () => {
-            dialog.showOpenDialog({
+            showOpenDialog({
                 properties: ['openFile'],
                 filters: [{
                     name: 'databases',

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -1,7 +1,20 @@
 import {contains} from 'ramda';
 
-export function dynamicRequireElectron() {
-    return window.require('electron');
+export function isElectron() {
+    // the electron's main process preloads a script that sets up `window.$falcon`
+    return Boolean(window.$falcon);
+}
+
+export function setUsernameListener(callback) {
+    if (isElectron()) {
+        window.$falcon.setUsernameListener(callback);
+    }
+}
+
+export function showOpenDialog(options, callback) {
+    if (isElectron()) {
+        return window.$falcon.showOpenDialog(options, callback);
+    }
 }
 
 export function baseUrl() {
@@ -38,10 +51,6 @@ export function plotlyUrl() {
         return window.location.origin;
     }
     return 'https://plot.ly';
-}
-
-export function isElectron() {
-    return window.process && window.process.type === 'renderer';
 }
 
 export function homeUrl() {

--- a/backend/constants.js
+++ b/backend/constants.js
@@ -1,5 +1,11 @@
 import {getSetting} from './settings';
 
+export function getUnsecuredCookieOptions() {
+    return {
+        path: getSetting('WEB_BASE_PATHNAME')
+    };
+}
+
 export function getCookieOptions() {
     return {
         secure: getSetting('SSL_ENABLED'),

--- a/backend/main.development.js
+++ b/backend/main.development.js
@@ -65,6 +65,12 @@ app.on('ready', () => {
         if (!url.startsWith(HTTP_URL)) event.preventDefault();
     });
 
+    // prevent navigation out of HTTP_URL
+    // see https://electronjs.org/docs/api/web-contents#event-will-navigate
+    mainWindow.webContents.on('new-window', (event, url) => {
+        if (!url.startsWith(HTTP_URL)) event.preventDefault();
+    });
+
     mainWindow.on('closed', () => {
         mainWindow = null;
     });

--- a/backend/main.development.js
+++ b/backend/main.development.js
@@ -1,4 +1,4 @@
-import {app, BrowserWindow} from 'electron';
+import {app, BrowserWindow, shell} from 'electron';
 import {contains} from 'ramda';
 import Logger from './logger';
 import {setupMenus} from './menus';
@@ -68,7 +68,8 @@ app.on('ready', () => {
     // prevent navigation out of HTTP_URL
     // see https://electronjs.org/docs/api/web-contents#event-will-navigate
     mainWindow.webContents.on('new-window', (event, url) => {
-        if (!url.startsWith(HTTP_URL)) event.preventDefault();
+        event.preventDefault();
+        shell.openExternal(url);
     });
 
     mainWindow.on('closed', () => {

--- a/backend/main.development.js
+++ b/backend/main.development.js
@@ -1,8 +1,10 @@
-import {app, BrowserWindow, shell} from 'electron';
-import {contains} from 'ramda';
-import Logger from './logger';
-import {setupMenus} from './menus';
+import {app, BrowserWindow, dialog, shell} from 'electron';
+import fs from 'fs';
 
+import {contains} from 'ramda';
+
+import Logger from './logger.js';
+import {setupMenus} from './menus.js';
 import Servers from './routes.js';
 
 Logger.log('Starting application', 2);
@@ -62,14 +64,46 @@ app.on('ready', () => {
     // prevent navigation out of HTTP_URL
     // see https://electronjs.org/docs/api/web-contents#event-will-navigate
     mainWindow.webContents.on('will-navigate', (event, url) => {
-        if (!url.startsWith(HTTP_URL)) event.preventDefault();
+        if (!url.startsWith(HTTP_URL)) {
+            Logger.log(`Preventing navigation to ${url}`, 2);
+            event.preventDefault();
+        }
     });
 
     // prevent navigation out of HTTP_URL
     // see https://electronjs.org/docs/api/web-contents#event-will-navigate
     mainWindow.webContents.on('new-window', (event, url) => {
         event.preventDefault();
-        shell.openExternal(url);
+
+        if (!url.startsWith('data:')) {
+            Logger.log(`Opening ${url}`, 2);
+            shell.openExternal(url);
+            return;
+        }
+
+        // only download data URLs that contain a CSV file
+        if (!url.startsWith('data:text/csv;base64,')) {
+            Logger.log(`Preventing request ${url}`, 2);
+            return;
+        }
+
+        dialog.showSaveDialog({
+            title: 'Save CSV File',
+            filters: [{
+                name: 'CSV files',
+                extensions: ['csv']
+            }]
+        }, (filename) => {
+            if (!filename) {
+                // silence error thrown when user cancels the save dialog
+                return;
+            }
+
+            fs.writeFileSync(
+                filename,
+                Buffer.from(url.slice(1 + url.indexOf(',')), 'base64').toString()
+            );
+        });
     });
 
     mainWindow.on('closed', () => {

--- a/backend/main.development.js
+++ b/backend/main.development.js
@@ -1,5 +1,6 @@
 import {app, BrowserWindow, dialog, shell} from 'electron';
 import fs from 'fs';
+import path from 'path';
 
 import {contains} from 'ramda';
 
@@ -28,7 +29,10 @@ server.queryScheduler.loadQueries();
 app.on('ready', () => {
 
     let mainWindow = new BrowserWindow({
-        show: true,
+        webPreferences: {
+            nodeIntegration: false,
+            preload: path.resolve(path.join(__dirname, 'preload.js'))
+        },
         width: 1024,
         height: 1024
     });

--- a/backend/plugins/authorization.js
+++ b/backend/plugins/authorization.js
@@ -1,9 +1,13 @@
-import {contains} from 'ramda';
-import {getSetting} from '../settings.js';
-import {getAccessTokenCookieOptions} from '../constants.js';
-import {generateAndSaveAccessToken} from '../utils/authUtils';
-import Logger from '../logger';
 import fetch from 'node-fetch';
+import {contains} from 'ramda';
+
+import {generateAndSaveAccessToken} from '../utils/authUtils.js';
+import {
+    getAccessTokenCookieOptions,
+    getUnsecuredCookieOptions
+} from '../constants.js';
+import Logger from '../logger.js';
+import {getSetting} from '../settings.js';
 
 /*
  * backend does not see `/external-data-connector` in on-prem (because it is proxied).
@@ -29,7 +33,14 @@ export function PlotlyOAuth(electron) {
     return function isAuthorized(req, res, next) {
         const path = req.href();
 
-        if (!getSetting('AUTH_ENABLED')) {
+        const clientId = process.env.PLOTLY_CONNECTOR_OAUTH2_CLIENT_ID ||
+            'isFcew9naom2f1khSiMeAtzuOvHXHuLwhPsM7oPt';
+        res.setCookie('db-connector-client-id', clientId, getUnsecuredCookieOptions());
+
+        const authEnabled = getSetting('AUTH_ENABLED');
+        res.setCookie('db-connector-auth-enabled', authEnabled, getUnsecuredCookieOptions());
+
+        if (!authEnabled) {
             return next();
         }
 

--- a/backend/preload.js
+++ b/backend/preload.js
@@ -1,0 +1,54 @@
+// this file is preloaded by electron in the renderer process
+// (it has access to electron's API, even when nodeIntegration has been disabled)
+
+const {ipcRenderer, remote} = require('electron');
+
+const propertyOptions = {
+    configurable: false,
+    enumerable: false,
+    writable: false
+};
+
+process.once('loaded', () => {
+    const $falcon = {};
+
+    Object.defineProperty(window, '$falcon', {
+        value: $falcon,
+        ...propertyOptions
+    });
+
+    Object.defineProperty($falcon, 'showOpenDialog', {
+        value: remote.dialog.showOpenDialog,
+        ...propertyOptions
+    });
+
+    let onUsername;
+    let receivedUsernameBeforeCallback;
+    let username;
+    function sendUsername(event, user) {
+        try {
+            if (onUsername) {
+                receivedUsernameBeforeCallback = false;
+                onUsername(event, user);
+            } else {
+                receivedUsernameBeforeCallback = true;
+                username = user;
+            }
+        } catch (error) {
+            console.error(error); // eslint-disable-line
+        }
+    }
+
+    ipcRenderer.on('username', sendUsername);
+
+    Object.defineProperty($falcon, 'setUsernameListener', {
+        value: (value) => {
+            onUsername = value;
+
+            if (receivedUsernameBeforeCallback) {
+                sendUsername(null, username);
+            }
+        },
+        ...propertyOptions
+    });
+});

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -1,13 +1,24 @@
+const fetch = require('node-fetch');
+import {contains, keys, isEmpty, merge, pluck} from 'ramda';
 const restify = require('restify');
 const CookieParser = require('restify-cookies');
-const fetch = require('node-fetch');
 
 import * as fs from 'fs';
 import path from 'path';
 
-import * as Datastores from './persistent/datastores/Datastores.js';
 import {PlotlyOAuth} from './plugins/authorization.js';
-import {getQueries, getQuery, deleteQuery} from './persistent/Queries';
+import {generateAndSaveAccessToken} from './utils/authUtils.js';
+import {
+    getAccessTokenCookieOptions,
+    getCookieOptions,
+    getUnsecuredCookieOptions
+} from './constants.js';
+import {getCerts, timeoutFetchAndSaveCerts, setRenewalJob} from './certificates.js';
+import * as Datastores from './persistent/datastores/Datastores.js';
+import init from './init.js';
+import Logger from './logger.js';
+import {checkWritePermissions, newDatacache} from './persistent/plotly-api.js';
+import {getQueries, getQuery, deleteQuery} from './persistent/Queries.js';
 import {
     deleteConnectionById,
     editConnectionById,
@@ -21,13 +32,7 @@ import {
 } from './persistent/Connections.js';
 import QueryScheduler from './persistent/QueryScheduler.js';
 import {getSetting, saveSetting} from './settings.js';
-import {generateAndSaveAccessToken} from './utils/authUtils';
-import {getAccessTokenCookieOptions, getCookieOptions} from './constants';
-import {checkWritePermissions, newDatacache} from './persistent/plotly-api.js';
-import {contains, keys, isEmpty, merge, pluck} from 'ramda';
-import {getCerts, timeoutFetchAndSaveCerts, setRenewalJob} from './certificates';
-import Logger from './logger';
-import init from './init.js';
+
 
 export default class Servers {
     /*
@@ -309,7 +314,7 @@ export default class Servers {
                         res.setCookie('db-connector-auth-token',
                                       db_connector_access_token,
                                       getAccessTokenCookieOptions());
-                        res.setCookie('db-connector-user', username, getCookieOptions());
+                        res.setCookie('db-connector-user', username, getUnsecuredCookieOptions());
 
                         const existingUsers = getSetting('USERS');
                         const existingUsernames = pluck('username', existingUsers);

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -613,13 +613,15 @@ export default class Servers {
             }
             else {
                 const rand = Math.round(Math.random() * 1000).toString();
-                const downloadPath = path.join(getSetting('STORAGE_PATH'), `data_export_${rand}.csv`);
+                const downloadPath = path.resolve(
+                    path.join(getSetting('STORAGE_PATH'), `data_export_${rand}.csv`)
+                );
                 fs.writeFile(downloadPath, payload, (err) => {
                     if (err) {
                         res.json({type: 'error', message: err});
                         return next();
                     }
-                    res.json({type: 'csv', url: 'file:///'.concat(downloadPath)});
+                    res.json({type: 'csv', url: 'file://'.concat(downloadPath)});
                     return next();
                 });
             }

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
   "dependencies": {
     "alasql": "^0.4.5",
     "csv-parse": "^2.0.0",
+    "dtrace-provider": "^0.8.6",
     "font-awesome": "^4.6.1",
     "ibm_db": "^2.3.0",
     "mysql": "^2.15.0",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -32,6 +32,7 @@ export default {
         {
             'csv-parse': 'commonjs csv-parse',
             'data-urls': 'commonjs data-urls',
+            'dtrace-provider': 'commonjs dtrace-provider',
             'font-awesome': 'font-awesome',
             'ibm_db': 'commonjs ibm_db',
             'mysql': 'mysql',

--- a/webpack.config.web.js
+++ b/webpack.config.web.js
@@ -2,13 +2,6 @@ import webpack from 'webpack';
 import baseConfig from './webpack.config.base';
 import path from 'path';
 
-const AUTH_ENABLED = process.env.PLOTLY_CONNECTOR_AUTH_ENABLED ?
-                     JSON.parse(process.env.PLOTLY_CONNECTOR_AUTH_ENABLED) : true;
-
-const OAUTH2_CLIENT_ID = process.env.PLOTLY_CONNECTOR_OAUTH2_CLIENT_ID ?
-    JSON.stringify(process.env.PLOTLY_CONNECTOR_OAUTH2_CLIENT_ID) :
-    JSON.stringify('isFcew9naom2f1khSiMeAtzuOvHXHuLwhPsM7oPt');
-
 const config = {
     ...baseConfig,
 
@@ -31,16 +24,6 @@ const config = {
         new webpack.DefinePlugin({
             __DEV__: false,
             'process.env.NODE_ENV': JSON.stringify('production')
-        }),
-
-        // This is used to pass environment variables to frontend
-        // detailed discussions on this ticket:
-        // https://github.com/plotly/streambed/issues/10436
-        new webpack.DefinePlugin({
-            'PLOTLY_ENV': {
-                'AUTH_ENABLED': AUTH_ENABLED,
-                'OAUTH2_CLIENT_ID': OAUTH2_CLIENT_ID
-            }
         })
     ],
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3096,6 +3096,12 @@ dtrace-provider@^0.8.2, dtrace-provider@~0.8:
   dependencies:
     nan "^2.3.3"
 
+dtrace-provider@^0.8.6:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
+  dependencies:
+    nan "^2.10.0"
+
 dtype@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dtype/-/dtype-1.0.0.tgz#ae34ffa282673715203582d61bbdd0aad3cba3e7"
@@ -6750,6 +6756,10 @@ mysql@^2.15.0:
     readable-stream "2.3.3"
     safe-buffer "5.1.1"
     sqlstring "2.3.0"
+
+nan@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
 nan@^2.3.0, nan@^2.3.3, nan@~2.7.0:
   version "2.7.0"


### PR DESCRIPTION
The main purpose of this PR is to disable `nodeIntegration` and strengthen the security measures in Falcon's frontend. To achieve this, I had to refactor some of the login code (so I took the opportunity to fix #260).

I've also included 2 other small fixes:
- https://github.com/plotly/falcon-sql-client/commit/2e09698214fe8abed33138d6b1190f5aa2eef7fb (issue #451, query panel doesn't open for non-sql connectors)
- https://github.com/plotly/falcon-sql-client/commit/2344f2cbd132401f17cc410b6cbd2a85471717a4 (rebased PR #422))

---

@tarzzz  could you review this PR, please?

@scjody are you OK with the changes in https://github.com/plotly/falcon-sql-client/commit/6100bba37fe1ed71788a63336c262df2a4e86047 and https://github.com/plotly/falcon-sql-client/commit/f3629210815f37998baf4af856983d142673a69c ? With these changes, we send the cookies `db-connector-auth-enabled`, `db-connector-client-id` and `db-connector-user` over HTTP.

@kndungu I think you'll be interested in reviewing the following commits (related to security in an electron app):

- to capture the event `new-window`:
  - https://github.com/plotly/falcon-sql-client/commit/5fff06692effe7b4c95e83100f94b51d96165f1c
  - https://github.com/plotly/falcon-sql-client/commit/90e5f7d1b4ec44f5f416418d22db28ddb566a171
  - https://github.com/plotly/falcon-sql-client/commit/9778cac9e8c277488d6314350f454edf9b63d665

 - to disable `nodeIntegration`: 
   - https://github.com/plotly/falcon-sql-client/commit/ce0be6252c3e650b5755aa227705f12ce8d921c4