### PR TITLE
scheduler: document reason to unset scheduledQuery

### DIFF
--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -272,6 +272,9 @@ class Settings extends Component {
     openScheduler() {
       this.setState({ scheduledQuery: this.props.preview.code }, () => {
         this.updateSelectedPanel(2, () => {
+          // Setting scheduledQuery to `null` right after opening the Schedule panel ensures that,
+          // when the user switches to another connector,
+          // `initialCode` isn't set to the `scheduledQuery` used in the previous connector.
           this.setState({ scheduledQuery: null });
         });
       });


### PR DESCRIPTION
@shannonlal I've added a comment to explain the reason why `scheduledQuery` is set to `null`. I want to check the explanation makes sense to everybody· Please, could you read it and see if it needs rewording?