### PR TITLE
settings: ensure login link is visible

### DIFF
--- a/app/components/Settings/Settings.react.js
+++ b/app/components/Settings/Settings.react.js
@@ -481,26 +481,31 @@ class Settings extends Component {
                                     ) : (
                                         <div>
                                             <p>
-                                                <a onClick={() => window.location.assign('/login')}>Log into Plotly</a>
-                                                <br/>
-                                                Log in to Plotly in order to schedule queries and make queries
-                                                directly from the <a href={`https://${plotlyUrl}/create`}>
-                                                Plotly Chart Studio </a>
+                                                Please connect to Plotly
+                                                to generate an SSL certificate and a URL for you.
                                             </p>
                                         </div>
-                                    )
-                                    }
+                                    )}
                                 </div>
                             ) : (
                                 <div className="big-whitespace-tab">
                                     <p>Please connect to a data store in the Connection tab first.</p>
                                 </div>
                             )}
-                            {username && <p style={{textAlign: 'right'}}>
-                                {`Logged in as "${username}"`}
-                                <br/>
-                                <a onClick={logout}>Log Out</a>
-                            </p>}
+
+                            {(username) ? (
+                                <p style={{textAlign: 'right'}}>
+                                    {`Logged in as "${username}"`}
+                                    <br/>
+                                    <a onClick={logout}>Log Out</a>
+                                </p>
+                            ) : (
+                                <p style={{textAlign: 'right'}}>
+                                    Not logged in
+                                    <br/>
+                                    <a onClick={() => window.location.assign('/login')}>Log into Plotly</a>
+                                </p>
+                            )}
                         </TabPanel> }
 
                         {isElectron() && <TabPanel>


### PR DESCRIPTION
@tarzzz could you review this PR, please?

---

The Plot.ly panel provides a link for users to log in and out of Plotly.

Unfortunately, the login link is hidden if the backend is able to launch the HTTPS server.

This PR ensures the login/logout link is always shown, regardless of the backend.

---

Before this PR

![screenshot from 2018-07-09 17-47-10](https://user-images.githubusercontent.com/6199391/42464181-31b26990-83a0-11e8-9585-6167329efc75.png)

---

With this PR

![image](https://user-images.githubusercontent.com/6199391/42464236-543d8558-83a0-11e8-9791-406eb29d8317.png)
