### PR TITLE
Rewrite grid updating functionality

### DIFF
--- a/app/actions/sessions.js
+++ b/app/actions/sessions.js
@@ -203,7 +203,7 @@ export function updateScheduledQuery(connectionId, payload = {}) {
       if (!res.error) {
         dispatch({
           type: 'UPDATE_SCHEDULED_QUERY',
-          payload: body
+          payload: res
         });
       }
       return res;

--- a/app/components/Settings/scheduler/create-modal.jsx
+++ b/app/components/Settings/scheduler/create-modal.jsx
@@ -6,12 +6,14 @@ import cronstrue from 'cronstrue';
 
 import {Row, Column} from '../../layout.jsx';
 import Modal from '../../modal.jsx';
+import {Link} from '../../Link.react';
 import SuccessMessage from '../../success.jsx';
 import RequestError from './request-error.jsx';
 import TimedMessage from './timed-message.jsx';
 import CronPicker from '../cron-picker/cron-picker.jsx';
 import SQL from './sql.jsx';
 
+import {datasetUrl as getDatasetURL} from '../../../utils/utils';
 import {getHighlightMode, WAITING_MESSAGE, SAVE_WARNING} from '../../../constants/constants.js';
 
 import './create-modal.css';
@@ -62,7 +64,8 @@ class CreateModal extends Component {
             name: props.initialName,
             interval: '*/5 * * * *',
             error: null,
-            saving: false
+            saving: false,
+            datasetUrl: null
         };
         this.options = {
             lineWrapping: true,
@@ -108,8 +111,12 @@ class CreateModal extends Component {
                 cronInterval: this.state.interval,
                 name: this.state.name ? this.state.name.trim() : ''
             })
-            .then(() => {
-                this.setState({successMessage: 'Scheduled query saved successfully!', saving: false});
+            .then((res) => {
+                this.setState({
+                  successMessage: 'Scheduled query saved successfully!',
+                  saving: false,
+                  datasetUrl: getDatasetURL(res.fid)
+                });
             })
             .catch(error => this.setState({error: error.message, saving: false}));
     }
@@ -193,7 +200,11 @@ class CreateModal extends Component {
                     </Column>
                     <Row>
                         {this.state.successMessage ? (
-                            <SuccessMessage>{this.state.successMessage}</SuccessMessage>
+                            <Column style={{ padding: '0 32px 16px' }}>
+                              <SuccessMessage message={this.state.successMessage}>
+                                <Link href={this.state.datasetUrl}>View Live Dataset</Link>
+                              </SuccessMessage>
+                            </Column>
                         ) : (
                             <Column>
                                 <button type="submit" className="submit" onClick={this.submit}>

--- a/app/components/Settings/scheduler/preview-modal.jsx
+++ b/app/components/Settings/scheduler/preview-modal.jsx
@@ -12,7 +12,7 @@ import {Link} from '../../Link.react.js';
 import CronPicker from '../cron-picker/cron-picker.jsx';
 import {Row, Column} from '../../layout.jsx';
 import SQL from './sql.jsx';
-import {plotlyUrl} from '../../../utils/utils.js';
+import {datasetUrl} from '../../../utils/utils.js';
 import {getHighlightMode, WAITING_MESSAGE, SAVE_WARNING} from '../../../constants/constants.js';
 import {getInitialCronMode} from '../cron-picker/cron-helpers.js';
 
@@ -156,7 +156,11 @@ export class PreviewModal extends Component {
         }
 
         if (success) {
-            return <SuccessMessage>{this.state.successMessage}</SuccessMessage>;
+            return (
+              <Column>
+                <SuccessMessage>{this.state.successMessage}</SuccessMessage>
+              </Column>
+            );
         }
 
         if (editing) {
@@ -196,8 +200,7 @@ export class PreviewModal extends Component {
         if (!props.query) {
             content = null;
         } else {
-            const [account, gridId] = props.query.fid.split(':');
-            const link = `${plotlyUrl()}/~${account}/${gridId}`;
+            const link = datasetUrl(props.query.fid);
             const {editing, loading} = this.state;
 
             const initialModeId = getInitialCronMode(props.query);

--- a/app/components/Settings/scheduler/preview-modal.jsx
+++ b/app/components/Settings/scheduler/preview-modal.jsx
@@ -308,7 +308,7 @@ export class PreviewModal extends Component {
                                 </div>
                             ) : (
                                 <em style={valueStyle}>
-                                    {props.query.cronInterval ? (
+                                    {this.state.cronInterval ? (
                                         <b>{cronstrue.toString(this.state.cronInterval)}</b>
                                     ) : (
                                         <React.Fragment>

--- a/app/components/success.jsx
+++ b/app/components/success.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const style = {marginBottom: 16, fontSize: 16, color: '#00cc96'};
+const style = {fontSize: 16};
 const SuccessMessage = (props) => (
-  <em style={style}>
+  <div style={{ padding: '8px 16px', borderLeft: '4px solid #00cc96', background: 'white'}}>
+    <div style={style}>{props.message}</div>
     {props.children}
-  </em>
+  </div>
 );
 
 SuccessMessage.propTypes = {
-  children: PropTypes.node
+  children: PropTypes.node,
+  message: PropTypes.string
 };
 
 export default SuccessMessage;

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -59,6 +59,11 @@ export function homeUrl() {
         '';
 }
 
+export function datasetUrl(fid) {
+  const [account, gridId] = fid.split(':');
+  return `${plotlyUrl()}/~${account}/${gridId}`;
+}
+
 export function getPathNames(url) {
     const parser = document.createElement('a');
     parser.href = url;

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -391,7 +391,8 @@ class QueryScheduler {
             Logger.log(`Request to Plotly for creating a grid took ${process.hrtime(startTime)[0]} seconds`, 2);
             Logger.log(`Grid ${fid} has been updated.`, 2);
 
-            if (res.status !== 200) {
+            // res is undefined if the `deleteQuery` is returned above
+            if (res && res.status && res.status !== 200) {
               throw new Error(`MetadataError: error updating grid metadata (status: ${res.status})`);
             }
 

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -37,7 +37,7 @@ class QueryScheduler {
 
         // this.job wraps this.queryAndUpdateGrid to avoid concurrent runs of the same job
         this.runningJobs = {};
-        this.job = (fid, uids, query, connectionId, requestor) => {
+        this.job = (fid, query, connectionId, requestor) => {
             try {
                 if (this.runningJobs[fid]) {
                     return;
@@ -45,7 +45,7 @@ class QueryScheduler {
 
                 this.runningJobs[fid] = true;
 
-                return this.queryAndUpdateGrid(fid, uids, query, connectionId, requestor)
+                return this.queryAndUpdateGrid(fid, query, connectionId, requestor)
                     .catch(error => {
                         Logger.log(error, 0);
                     }).then(() => {
@@ -239,7 +239,7 @@ class QueryScheduler {
         });
     }
 
-    queryAndUpdateGrid(fid, uids, query, connectionId, requestor, cronInterval, refreshInterval) {
+    queryAndUpdateGrid(fid, query, connectionId, requestor, cronInterval, refreshInterval) {
         const requestedDBConnections = getConnectionById(connectionId);
         const formattedRefresh = refreshInterval || mapCronToRefresh(cronInterval);
         let startTime = process.hrtime();
@@ -298,7 +298,6 @@ class QueryScheduler {
                 rows,
                 columnnames,
                 fid,
-                uids,
                 requestor
             ).catch((e) => {
                 /*

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -387,19 +387,25 @@ class QueryScheduler {
                 */
                 throw new Error(`MetadataError: ${e.message}`);
             });
-        }).then(() => {
+        }).then(res => {
             Logger.log(`Request to Plotly for creating a grid took ${process.hrtime(startTime)[0]} seconds`, 2);
             Logger.log(`Grid ${fid} has been updated.`, 2);
+
+            if (res.status !== 200) {
+              throw new Error(`MetadataError: error updating grid metadata (status: ${res.status})`);
+            }
 
             startTime = process.hrtime();
 
             // fetch updated grid column for returning
             return getGridColumn(fid, requestor);
-        }).then((res) => {
+        }).then(res => {
             Logger.log(`Request to Plotly for fetching updated grid took ${process.hrtime(startTime)[0]} seconds`, 2);
+
             if (res.status !== 200) {
-              return res.text();
+              throw new Error(`PlotlyApiError: error fetching updated columns (status: ${res.status})`);
             }
+
             return res.json();
         });
     }

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -21,7 +21,7 @@ import {
     newGrid,
     patchGrid,
     updateGrid,
-    getGrid
+    getGridColumn
 } from './plotly-api.js';
 
 const SUCCESS_CODES = [200, 201, 204];
@@ -393,8 +393,8 @@ class QueryScheduler {
 
             startTime = process.hrtime();
 
-            // fetch updated grid for returning
-            return getGrid(fid, requestor);
+            // fetch updated grid column for returning
+            return getGridColumn(fid, requestor);
         }).then((res) => {
             Logger.log(`Request to Plotly for fetching updated grid took ${process.hrtime(startTime)[0]} seconds`, 2);
             if (res.status !== 200) {

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -37,15 +37,14 @@ class QueryScheduler {
 
         // this.job wraps this.queryAndUpdateGrid to avoid concurrent runs of the same job
         this.runningJobs = {};
-        this.job = (fid, query, connectionId, requestor) => {
+        this.job = (fid, query, connectionId, requestor, cronInterval, refreshInterval) => {
             try {
                 if (this.runningJobs[fid]) {
                     return;
                 }
 
                 this.runningJobs[fid] = true;
-
-                return this.queryAndUpdateGrid(fid, query, connectionId, requestor)
+                return this.queryAndUpdateGrid(fid, query, connectionId, requestor, cronInterval, refreshInterval)
                     .catch(error => {
                         Logger.log(error, 0);
                     }).then(() => {
@@ -116,7 +115,7 @@ class QueryScheduler {
         saveQuery(queryParams);
 
         // Schedule
-        const job = () => this.job(fid, uids, query, connectionId, requestor);
+        const job = () => this.job(fid, query, connectionId, requestor, cronInterval, refreshInterval);
         let jobInterval = cronInterval;
         if (!jobInterval) {
             // convert refresh interval to cron representation

--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -397,6 +397,9 @@ class QueryScheduler {
             return getGrid(fid, requestor);
         }).then((res) => {
             Logger.log(`Request to Plotly for fetching updated grid took ${process.hrtime(startTime)[0]} seconds`, 2);
+            if (res.status !== 200) {
+              return res.text();
+            }
             return res.json();
         });
     }

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -6,6 +6,7 @@ import {
     getCredentials,
     getSetting
 } from '../settings.js';
+import {extractOrderedUids} from '../utils/gridUtils.js';
 
 
 // Module to access Plot.ly REST API
@@ -164,7 +165,7 @@ export function patchGrid(fid, requestor, body) {
     });
 }
 
-export function updateGrid(rows, columnnames, fid, _unusedUIDs, requestor) {
+export function updateGrid(rows, columnnames, fid, requestor) {
     const numColumns = columnnames.length;
     const columns = getColumns(rows, numColumns);
     const columnEntries = columns.map((column, columnIndex) => {
@@ -188,10 +189,7 @@ export function updateGrid(rows, columnnames, fid, _unusedUIDs, requestor) {
               return data;
           }
 
-          const uids = Object.keys(data.cols)
-            .map(key => data.cols[key])
-            .sort((a, b) => a.order - b.order)
-            .map(col => col.uid);
+          const uids = extractOrderedUids(data);
 
           if (numColumns > uids.length) {
               // repopulate existing columns

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -165,6 +165,17 @@ export function patchGrid(fid, requestor, body) {
     });
 }
 
+export function getGridColumn(fid, requestor) {
+    const {username, apiKey, accessToken} = getCredentials(requestor);
+
+    return plotlyAPIRequest(`grids/${fid}/col`, {
+        method: 'GET',
+        username,
+        apiKey,
+        accessToken
+    });
+}
+
 export function updateGrid(rows, columnnames, fid, requestor) {
     const numColumns = columnnames.length;
     const columns = getColumns(rows, numColumns);
@@ -177,7 +188,7 @@ export function updateGrid(rows, columnnames, fid, requestor) {
     const baseParams = { username, apiKey, accessToken };
 
     // fetch latest grid to get the source of truth
-    return plotlyAPIRequest(baseUrl, { ...baseParams, method: 'GET' })
+    return getGridColumn(fid, requestor)
         .then(res => {
             if (res.status !== 200) {
                 return res;

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -178,76 +178,78 @@ export function updateGrid(rows, columnnames, fid, requestor) {
 
     // fetch latest grid to get the source of truth
     return getGrid(fid, requestor)
-      .then(res => {
-          if (res.status !== 200) {
-              return res;
-          }
-          return res.json();
-      }).then(data => {
-          if (data.status) {
-              // bad res was passed along, return it
-              return data;
-          }
+        .then(res => {
+            if (res.status !== 200) {
+                return res;
+            }
+            return res.json();
+        }).then(data => {
+            if (data.status) {
+                // bad res was passed along, return it
+                return data;
+            }
 
-          const uids = extractOrderedUids(data);
+            const uids = extractOrderedUids(data);
 
-          if (numColumns > uids.length) {
-              // repopulate existing columns
-              const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
-              const putBody = { cols: columnEntries.slice(0, uids.length) };
+            if (numColumns > uids.length) {
+                // repopulate existing columns
+                const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
+                const putBody = { cols: columnEntries.slice(0, uids.length) };
 
-              // append new columns
-              const postUrl = baseUrl;
-              const postBody = { cols: columnEntries.slice(uids.length) };
+                // append new columns
+                const postUrl = baseUrl;
+                const postBody = { cols: columnEntries.slice(uids.length) };
 
-              return plotlyAPIRequest(postUrl, {
-                  ...baseParams,
-                  body: postBody,
-                  method: 'POST'
-              }).then((res) => {
-                  if (res.status !== 200) {
-                      return res;
-                  }
+                return plotlyAPIRequest(postUrl, {
+                    ...baseParams,
+                    body: postBody,
+                    method: 'POST'
+                }).then((res) => {
+                    if (res.status !== 200) {
+                        return res;
+                    }
 
-                  return plotlyAPIRequest(putUrl, {
-                      ...baseParams,
-                      body: putBody,
-                      method: 'PUT'
-                  });
-              });
-          } else if (numColumns < uids.length) {
-              // repopulate existing columns
-              const putUrl = `${baseUrl}?uid=${uids.slice(0, numColumns).join(',')}`;
-              const putBody = { cols: columnEntries };
+                    return plotlyAPIRequest(putUrl, {
+                        ...baseParams,
+                        body: putBody,
+                        method: 'PUT'
+                    });
+                });
+            } else if (numColumns < uids.length) {
+                // delete unused existing columns
+                const deleteUrl = `${baseUrl}?uid=${uids.slice(numColumns)}`;
 
-              // delete unused existing columns
-              const deleteUrl = `${baseUrl}?uid=${uids.slice(numColumns)}`;
+                // repopulate used existing columns
+                const putUrl = `${baseUrl}?uid=${uids.slice(0, numColumns).join(',')}`;
+                const putBody = { cols: columnEntries };
 
-              return plotlyAPIRequest(putUrl, {
-                  ...baseParams,
-                  body: putBody,
-                  method: 'PUT'
-              }).then((res) => {
-                  if (res.status !== 200) {
-                      return res;
-                  }
 
-                  return plotlyAPIRequest(deleteUrl, {
-                      ...baseParams,
-                      method: 'DELETE'
-                  });
-              });
-          }
 
-          // repopulate existing columns
-          const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
-          const putBody = { cols: columnEntries };
+                return plotlyAPIRequest(deleteUrl, {
+                    ...baseParams,
+                    method: 'DELETE'
+                }).then((res) => {
+                    if (res.status !== 204) {
+                        return res;
+                    }
 
-          return plotlyAPIRequest(putUrl, {
-              ...baseParams,
-              body: putBody,
-              method: 'PUT'
-          });
+                    return plotlyAPIRequest(putUrl, {
+                        ...baseParams,
+                        body: putBody,
+                        method: 'PUT'
+                    });
+                });
+            }
+
+            // repopulate existing columns
+            const putUrl = `${baseUrl}?uid=${uids.join(',')}`;
+            const putBody = { cols: columnEntries };
+
+            return plotlyAPIRequest(putUrl, {
+                ...baseParams,
+                body: putBody,
+                method: 'PUT'
+            });
     });
 }
 

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -175,10 +175,19 @@ export function updateGrid(rows, columnnames, fid, _unusedUIDs, requestor) {
     const baseUrl = `grids/${fid}/col`;
     const baseParams = { username, apiKey, accessToken };
 
-    // Fetch latest Grid to get the source of truth
+    // fetch latest grid to get the source of truth
     return getGrid(fid, requestor)
-      .then(res => res.json())
-      .then(data => {
+      .then(res => {
+          if (res.status !== 200) {
+              return res;
+          }
+          return res.json();
+      }).then(data => {
+          if (data.status) {
+              // bad res was passed along, return it
+              return data;
+          }
+
           const uids = Object.keys(data.cols)
             .map(key => data.cols[key])
             .sort((a, b) => a.order - b.order)

--- a/backend/persistent/plotly-api.js
+++ b/backend/persistent/plotly-api.js
@@ -177,7 +177,7 @@ export function updateGrid(rows, columnnames, fid, requestor) {
     const baseParams = { username, apiKey, accessToken };
 
     // fetch latest grid to get the source of truth
-    return getGrid(fid, requestor)
+    return plotlyAPIRequest(baseUrl, { ...baseParams, method: 'GET' })
         .then(res => {
             if (res.status !== 200) {
                 return res;

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -8,6 +8,7 @@ import path from 'path';
 
 import {PlotlyOAuth} from './plugins/authorization.js';
 import {generateAndSaveAccessToken} from './utils/authUtils.js';
+import {extractOrderedUids} from './utils/gridUtils.js';
 import {
     getAccessTokenCookieOptions,
     getCookieOptions,
@@ -667,7 +668,6 @@ export default class Servers {
             const {
                 filename,
                 fid,
-                uids,
                 query,
                 connectionId,
                 requestor,
@@ -700,29 +700,34 @@ export default class Servers {
             if (fid) {
                 return checkWritePermissions(fid, requestor).then(function () {
                     return that.queryScheduler.queryAndUpdateGrid(
-                        fid, uids, query, connectionId, requestor, cronInterval, refreshInterval
+                        fid, query, connectionId, requestor, cronInterval, refreshInterval
                     );
                 })
                 .then((updatedGridResponse) => {
-                    const orderedUids =
-                        Object.keys(updatedGridResponse.cols)
-                        .map(key => updatedGridResponse.cols[key])
-                        .sort((a, b) => a.order - b.order)
-                        .map(col => col.uid);
-
-                    const queryObject = {
-                        ...req.params,
-                        uids: orderedUids
-                    };
+                    const orderedUids = extractOrderedUids(updatedGridResponse);
+                    const previousQuery = getQuery(req.params.fid);
 
                     let status;
-                    if (getQuery(req.params.fid)) {
+                    if (previousQuery) {
                         // TODO - Technically, this should be
                         // under the endpoint `/queries/:fid`
                         status = 200;
                     } else {
                         status = 201;
                     }
+
+                    let oldParamsToCarryOver = {};
+                    if (previousQuery) {
+                        const {name} = previousQuery;
+                        oldParamsToCarryOver = {name};
+                    }
+
+                    const queryObject = {
+                        ...oldParamsToCarryOver,
+                        ...req.params,
+                        uids: orderedUids
+                    };
+
                     that.queryScheduler.scheduleQuery(queryObject);
                     res.json(status, queryObject);
                     return next();

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -703,7 +703,18 @@ export default class Servers {
                         fid, uids, query, connectionId, requestor, cronInterval, refreshInterval
                     );
                 })
-                .then(() => {
+                .then((updatedGridResponse) => {
+                    const orderedUids =
+                        Object.keys(updatedGridResponse.cols)
+                        .map(key => updatedGridResponse.cols[key])
+                        .sort((a, b) => a.order - b.order)
+                        .map(col => col.uid);
+
+                    const queryObject = {
+                        ...req.params,
+                        uids: orderedUids
+                    };
+
                     let status;
                     if (getQuery(req.params.fid)) {
                         // TODO - Technically, this should be
@@ -712,8 +723,8 @@ export default class Servers {
                     } else {
                         status = 201;
                     }
-                    that.queryScheduler.scheduleQuery(req.params);
-                    res.json(status, {});
+                    that.queryScheduler.scheduleQuery(queryObject);
+                    res.json(status, queryObject);
                     return next();
                 })
                 .catch(onError);

--- a/backend/utils/gridUtils.js
+++ b/backend/utils/gridUtils.js
@@ -1,0 +1,10 @@
+export function extractOrderedUids (grid) {
+  try {
+    return Object.keys(grid.cols)
+      .map(key => grid.cols[key])
+      .sort((a, b) => a.order - b.order)
+      .map(col => col.uid);
+  } catch (e) {
+    return null;
+  }
+}

--- a/test/app/components/Settings/scheduler/preview-modal.test.jsx
+++ b/test/app/components/Settings/scheduler/preview-modal.test.jsx
@@ -64,7 +64,7 @@ describe('Preview Modal Tests', () => {
                 .find('button')
                 .at(1)
                 .text()
-        ).toEqual(expect.stringContaining('Log in'));
+        ).toEqual(expect.stringContaining('Switch users'));
     });
 
     it('should render edit and delete buttons if logged in', () => {

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -622,8 +622,7 @@ describe('QueryScheduler', function() {
         }
 
         function resetAndVerifyGridContents(fid, uids) {
-            const placeholderColNames = Array(uids.length).fill('_');
-            return updateGrid([[1, 2, 3, 4, 5, 6]], placeholderColNames, fid, uids, username, apiKey)
+            return updateGrid([[1, 2, 3, 4, 5, 6]], names, fid, uids, username, apiKey)
             .then(assertResponseStatus(200)).then(() => {
                 return getGrid(fid, username);
             })

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -622,7 +622,8 @@ describe('QueryScheduler', function() {
         }
 
         function resetAndVerifyGridContents(fid, uids) {
-            return updateGrid([[1, 2, 3, 4, 5, 6]], fid, uids, username, apiKey)
+            const placeholderColNames = Array(uids.length).fill('_');
+            return updateGrid([[1, 2, 3, 4, 5, 6]], placeholderColNames, fid, uids, username, apiKey)
             .then(assertResponseStatus(200)).then(() => {
                 return getGrid(fid, username);
             })

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -624,8 +624,8 @@ describe('QueryScheduler', function() {
             });
         }
 
-        function resetAndVerifyGridContents(fid, uids) {
-            return updateGrid([[1, 2, 3, 4, 5, 6]], names, fid, uids, username, apiKey)
+        function resetAndVerifyGridContents(fid) {
+            return updateGrid([[1, 2, 3, 4, 5, 6]], names, fid, username, apiKey)
             .then(assertResponseStatus(200)).then(() => {
                 return getGrid(fid, username);
             })
@@ -673,7 +673,7 @@ describe('QueryScheduler', function() {
         })
         .then(() => wait(1.5 * refreshInterval * 1000))
         .then(() => checkGridAgainstQuery(fid, 'First check'))
-        .then(() => resetAndVerifyGridContents(fid, uids))
+        .then(() => resetAndVerifyGridContents(fid))
         .then(() => wait(1.5 * refreshInterval * 1000))
         .then(() => checkGridAgainstQuery(fid, 'Second check'))
         .then(() => deleteGrid(fid, username));

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 import sinon from 'sinon';
 
-import {merge} from 'ramda';
+import {merge, omit} from 'ramda';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
 import {
@@ -528,7 +528,7 @@ describe('QueryScheduler', function() {
 
     it('clears and deletes the query if its associated grid was deleted', function() {
         const refreshInterval = 5;
-        const cronInterval = `*/${refreshInterval} * * * * *`;
+        const cronInterval = `*/${refreshInterval} * * * * *`; // every 5 seconds
 
         /*
          * Save the sqlConnections to a file.
@@ -550,7 +550,6 @@ describe('QueryScheduler', function() {
             queryObject = {
                 fid,
                 uids,
-                refreshInterval,
                 cronInterval,
                 connectionId,
                 query: 'SELECT * from ebola_2014 LIMIT 2',
@@ -562,7 +561,11 @@ describe('QueryScheduler', function() {
 
             queryScheduler.scheduleQuery(queryObject);
 
-            assert.deepEqual(getQueries(), [queryObject], 'Query has not been saved');
+            assert.deepEqual(
+                getQueries().map(query => omit('refreshInterval', query)),
+                [queryObject],
+                'Query has not been saved'
+            );
             assert(Boolean(queryScheduler.queryJobs[fid]), 'Query has not been scheduled');
 
             return deleteGrid(fid, username);

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 import sinon from 'sinon';
 
-import {merge, omit} from 'ramda';
+import {merge} from 'ramda';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
 import {
@@ -550,6 +550,7 @@ describe('QueryScheduler', function() {
             queryObject = {
                 fid,
                 uids,
+                refreshInterval,
                 cronInterval,
                 connectionId,
                 query: 'SELECT * from ebola_2014 LIMIT 2',
@@ -562,7 +563,7 @@ describe('QueryScheduler', function() {
             queryScheduler.scheduleQuery(queryObject);
 
             assert.deepEqual(
-                getQueries().map(query => omit('refreshInterval', query)),
+                getQueries(),
                 [queryObject],
                 'Query has not been saved'
             );

--- a/test/backend/QueryScheduler.spec.js
+++ b/test/backend/QueryScheduler.spec.js
@@ -464,13 +464,13 @@ describe('QueryScheduler', function() {
         clock.tick(3.25 * refreshInterval * 1000);
         assert(spy1.calledThrice, 'job1 should have been called three times');
         assert(spy1.alwaysCalledWith(
-            query.fid, query.uids, query.query,
+            query.fid, query.query,
             query.connectionId, query.requestor
         ), `job1 was called with unexpected args: ${spy1.args}`);
         assert(spy2.calledThrice, 'job2 should have been called three times');
         assert(spy2.alwaysCalledWith(
-            query.fid, query.uids, 'query-2',
-            query.connectionId, query.requestor
+            query.fid, 'query-2',
+            query.connectionId, query.requestor,
         ), `job2 was called with unexpected args: ${spy2.args}`);
 
         clock.restore();

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -13,7 +13,14 @@ import {
     initGrid,
     username
 } from './utils.js';
+import {extractOrderedUids} from '../../backend/utils/gridUtils.js';
 
+function genPlaceholderColumnNames (numColumns) {
+    return Array(numColumns).fill('_').map((_, index) => `placeholder-${index}`);
+}
+
+// Note: in the following tests grids are created to begin with, but
+// the actual backend never does this — it assumes a grid already exists.
 describe('Grid API Functions', function () {
     before(() => {
         saveSetting('USERS', [{username, apiKey}]);
@@ -21,14 +28,112 @@ describe('Grid API Functions', function () {
         saveSetting('PLOTLY_API_SSL_ENABLED', true);
     });
 
-    it('updateGrid overwrites a grid with new data', function () {
-        // First, create a new grid.
-        // Note that the app never actually does this,
-        // it works off of the assumption that a grid exists
+    it('updateGrid updates a grid but keeps the same uids', function () {
+        let fid, originalUids;
+        return initGrid('test grid')
+            .then(assertResponseStatus(201))
+            .then(getResponseJson)
+            .then(json => {
+                originalUids = json.file.cols.map(col => col.uid);
+                fid = json.file.fid;
 
+                return updateGrid(
+                    [
+                        ['x', 10, 40, 70, 100, 130],
+                        ['y', 20, 50, 80, 110, 140],
+                        ['z', 30, 60, 90, 120, 150]
+                    ],
+                    genPlaceholderColumnNames(6),
+                    fid,
+                    username
+                );
+            })
+            .then(assertResponseStatus(200))
+            .then(() => {
+                return getGrid(fid, username);
+            })
+            .then(assertResponseStatus(200))
+            .then(getResponseJson)
+            .then(json => {
+                const finalUids = extractOrderedUids(json);
+                assert.equal(finalUids.length, 6);
+                assert.deepEqual(originalUids, finalUids, 'original and final uids differ');
+            })
+            .then(() => deleteGrid(fid, username));
+    });
+
+    it('updateGrid keeps all original uids when appending additional columns', function () {
+        let fid, originalUids;
+        return initGrid('test grid')
+            .then(assertResponseStatus(201))
+            .then(getResponseJson)
+            .then(json => {
+                originalUids = json.file.cols.map(col => col.uid);
+                fid = json.file.fid;
+
+                return updateGrid(
+                    [
+                        ['x', 10, 40, 70, 100, 130, 160, 190],
+                        ['y', 20, 50, 80, 110, 140, 170, 200],
+                        ['z', 30, 60, 90, 120, 150, 180, 210]
+                    ],
+                    genPlaceholderColumnNames(8),
+                    fid,
+                    username
+                );
+            })
+            .then(assertResponseStatus(201))
+            .then(() => {
+                return getGrid(fid, username);
+            })
+            .then(assertResponseStatus(200))
+            .then(getResponseJson)
+            .then(json => {
+                const finalUids = extractOrderedUids(json);
+                assert.equal(finalUids.length, 8);
+                assert.deepEqual(originalUids, finalUids.slice(0, 6), 'original and final uids differ');
+            })
+            .then(() => deleteGrid(fid, username));
+    });
+
+    it('updateGrid keeps subset of original uids when deleting columns', function () {
+        let fid, originalUids;
+        return initGrid('test grid')
+            .then(assertResponseStatus(201))
+            .then(getResponseJson)
+            .then(json => {
+                originalUids = json.file.cols.map(col => col.uid);
+                fid = json.file.fid;
+
+                return updateGrid(
+                    [
+                        ['x', 10, 40, 70],
+                        ['y', 20, 50, 80],
+                        ['z', 30, 60, 90]
+                    ],
+                    genPlaceholderColumnNames(4),
+                    fid,
+                    username
+                );
+            })
+            .then(assertResponseStatus(200))
+            .then(() => {
+                return getGrid(fid, username);
+            })
+            .then(assertResponseStatus(200))
+            .then(getResponseJson)
+            .then(json => {
+                const finalUids = extractOrderedUids(json);
+                assert.equal(finalUids.length, 4);
+                assert.deepEqual(originalUids.slice(0, 4), finalUids, 'original and final uids differ');
+            })
+            .then(() => deleteGrid(fid, username));
+    });
+
+    it('updateGrid overwrites a grid with correct data and column names', function () {
         let fid;
-        const newColumnNames = Array(6).fill('_').map((v, i) => String(i)); // placeholder column names
-        return initGrid('Test updateGrid')
+        const placeholderColumnNames = genPlaceholderColumnNames(6);
+        return initGrid('test grid')
         .then(assertResponseStatus(201))
         .then(getResponseJson).then(json => {
             fid = json.file.fid;
@@ -38,7 +143,7 @@ describe('Grid API Functions', function () {
                     ['y', 20, 50, 80, 110, 140],
                     ['z', 30, 60, 90, 120, 150]
                 ],
-                newColumnNames, // placeholder column names
+                placeholderColumnNames,
                 fid,
                 username
             );
@@ -50,27 +155,27 @@ describe('Grid API Functions', function () {
         .then(assertResponseStatus(200))
         .then(getResponseJson).then(json => {
             assert.deepEqual(
-                json.cols[newColumnNames[0]].data,
+                json.cols[placeholderColumnNames[0]].data,
                 ['x', 'y', 'z']
             );
             assert.deepEqual(
-                json.cols[newColumnNames[1]].data,
+                json.cols[placeholderColumnNames[1]].data,
                 [10, 20, 30]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[2]].data,
+                json.cols[placeholderColumnNames[2]].data,
                 [40, 50, 60]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[3]].data,
+                json.cols[placeholderColumnNames[3]].data,
                 [70, 80, 90]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[4]].data,
+                json.cols[placeholderColumnNames[4]].data,
                 [100, 110, 120]
             );
             assert.deepEqual(
-                json.cols[newColumnNames[5]].data,
+                json.cols[placeholderColumnNames[5]].data,
                 [130, 140, 150]
             );
         })

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -32,7 +32,6 @@ describe('Grid API Functions', function () {
         .then(assertResponseStatus(201))
         .then(getResponseJson).then(json => {
             fid = json.file.fid;
-            const uids = json.file.cols.map(col => col.uid);
             return updateGrid(
                 [
                     ['x', 10, 40, 70, 100, 130],
@@ -41,7 +40,6 @@ describe('Grid API Functions', function () {
                 ],
                 newColumnNames, // placeholder column names
                 fid,
-                uids,
                 username
             );
         })

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -39,6 +39,7 @@ describe('Grid API Functions', function () {
                     ['y', 20, 50, 80, 110, 140],
                     ['z', 30, 60, 90, 120, 150]
                 ],
+                Array(3).fill('_'), // placeholder column names
                 fid,
                 uids,
                 username

--- a/test/backend/plotly-api.spec.js
+++ b/test/backend/plotly-api.spec.js
@@ -11,7 +11,6 @@ import {
     assertResponseStatus,
     getResponseJson,
     initGrid,
-    names,
     username
 } from './utils.js';
 
@@ -28,6 +27,7 @@ describe('Grid API Functions', function () {
         // it works off of the assumption that a grid exists
 
         let fid;
+        const newColumnNames = Array(6).fill('_').map((v, i) => String(i)); // placeholder column names
         return initGrid('Test updateGrid')
         .then(assertResponseStatus(201))
         .then(getResponseJson).then(json => {
@@ -39,7 +39,7 @@ describe('Grid API Functions', function () {
                     ['y', 20, 50, 80, 110, 140],
                     ['z', 30, 60, 90, 120, 150]
                 ],
-                Array(3).fill('_'), // placeholder column names
+                newColumnNames, // placeholder column names
                 fid,
                 uids,
                 username
@@ -52,27 +52,27 @@ describe('Grid API Functions', function () {
         .then(assertResponseStatus(200))
         .then(getResponseJson).then(json => {
             assert.deepEqual(
-                json.cols[names[0]].data,
+                json.cols[newColumnNames[0]].data,
                 ['x', 'y', 'z']
             );
             assert.deepEqual(
-                json.cols[names[1]].data,
+                json.cols[newColumnNames[1]].data,
                 [10, 20, 30]
             );
             assert.deepEqual(
-                json.cols[names[2]].data,
+                json.cols[newColumnNames[2]].data,
                 [40, 50, 60]
             );
             assert.deepEqual(
-                json.cols[names[3]].data,
+                json.cols[newColumnNames[3]].data,
                 [70, 80, 90]
             );
             assert.deepEqual(
-                json.cols[names[4]].data,
+                json.cols[newColumnNames[4]].data,
                 [100, 110, 120]
             );
             assert.deepEqual(
-                json.cols[names[5]].data,
+                json.cols[newColumnNames[5]].data,
                 [130, 140, 150]
             );
         })

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -128,7 +128,9 @@ describe('Routes:', () => {
                 });
         });
 
-        it('can register queries if the user is a collaborator', function() {
+        // disabled because collaborators cannot register queries since
+        // they lack permission to update metadata
+        xit('can register queries if the user is a collaborator', function() {
             /*
              * Plotly doesn't have a v2 endpoint for creating
              * collaborators, so we'll just use these hardcoded

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -159,7 +159,7 @@ describe('Routes:', () => {
             return POST('queries', queryObject)
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then((json) => {
-                    assert.deepEqual(json, {
+                    queryObject = {
                       ...queryObject,
                       uids: [
                         '08bd63',
@@ -169,11 +169,12 @@ describe('Routes:', () => {
                         '3c7496',
                         'b6b0bb'
                       ]
-                    });
-                    return GET('queries').then(getResponseJson)
-                      .then((getResponse) => {
-                        assert.deepEqual(getResponse, [json]);
-                      });
+                    };
+                    assert.deepEqual(json, queryObject);
+                    return GET('queries');
+                })
+                .then(getResponseJson).then((json) => {
+                    assert.deepEqual(json, [queryObject]);
                 });
         });
 

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {merge} from 'ramda';
+import {merge, omit} from 'ramda';
 import uuid from 'uuid';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
@@ -17,8 +17,7 @@ import {
     POST,
     sqlConnections,
     username,
-    validFid,
-    validUids
+    validFid
 } from './utils.js';
 
 
@@ -34,7 +33,6 @@ describe('Routes:', () => {
         connectionId = saveConnection(sqlConnections);
         queryObject = {
             fid: validFid,
-            uids: validUids.slice(0, 2), // since this particular query only has 2 columns
             refreshInterval: 60, // every minute
             cronInterval: null,
             query: 'SELECT * FROM ebola_2014 LIMIT 1',
@@ -102,12 +100,10 @@ describe('Routes:', () => {
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then(json => {
                     fid = json.file.fid;
-                    const uids = json.file.cols.map(col => col.uid);
 
                     queryObject = {
                         fid,
                         requestor: fid.split(':')[0],
-                        uids,
                         refreshInterval: 60,
                         cronInterval: null,
                         connectionId,
@@ -118,12 +114,15 @@ describe('Routes:', () => {
                 })
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(json, queryObject);
+                    assert.deepEqual(omit(json, 'uids'), omit(queryObject, 'uids'));
+                    assert.equal(json.uids.length, 6);
 
                     return GET('queries');
                 })
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(json, [queryObject]);
+                    assert.equal(json.length, 1);
+                    assert.deepEqual(omit(json[0], 'uids'), omit(queryObject, 'uids'));
+                    assert.equal(json[0].uids.length, 6);
 
                     return deleteGrid(fid, username);
                 });
@@ -144,12 +143,10 @@ describe('Routes:', () => {
                 apiKey: 'I6j80cqCVaBAnvH9ESD2'
             }]);
             const fid = 'plotly-database-connector:718';
-            const uids = ['d8ba6c', 'dfa411'];
 
             queryObject = {
                 fid,
                 requestor: collaborator,
-                uids,
                 refreshInterval: 60,
                 cronInterval: null,
                 connectionId,
@@ -186,12 +183,10 @@ describe('Routes:', () => {
                 apiKey: 'mUSjMmwa55d6hjvwvgI4'
             }]);
             const fid = 'plotly-database-connector:718';
-            const uids = ['d8ba6c', 'dfa411'];
 
             queryObject = {
                 fid,
                 requestor: viewer,
-                uids,
                 refreshInterval: 60,
                 cronInterval: null,
                 connectionId,
@@ -223,12 +218,10 @@ describe('Routes:', () => {
              * plot
              */
             const fid = 'plotly-database-connector:719';
-            const uids = ['3a6df9', 'b95e9d'];
 
             queryObject = {
                 fid,
                 requestor: viewer,
-                uids,
                 refreshInterval: 60,
                 cronInterval: null,
                 connectionId,

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -237,34 +237,19 @@ describe('Routes:', () => {
         });
 
         it('gets individual queries', function() {
-          // uids are hardcoded
-          const uids = [
-            '9bbb87',
-            '8d4dd0',
-            '3e40ef',
-            'b169c0',
-            '55e326',
-            'e69f70'
-          ];
-          return GET(`queries/${queryObject.fid}`)
-              .then(assertResponseStatus(404)).then(() => {
-                  return POST('queries', queryObject);
-              })
-              .then(assertResponseStatus(201))
-              .then(getResponseJson).then(json => {
-                  assert.deepEqual(json, {
-                    ...queryObject,
-                    uids
-                  });
-                  return GET(`queries/${queryObject.fid}`);
-              })
-              .then(assertResponseStatus(200))
-              .then(getResponseJson).then(json => {
-                  assert.deepEqual(json, {
-                    ...queryObject,
-                    uids
-                  });
-              });
+            return GET(`queries/${queryObject.fid}`)
+                .then(assertResponseStatus(404)).then(() => {
+                    return POST('queries', queryObject);
+                })
+                .then(assertResponseStatus(201))
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                    return GET(`queries/${queryObject.fid}`);
+                })
+                .then(assertResponseStatus(200))
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                });
         });
 
         it('deletes queries', function() {

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {merge, omit} from 'ramda';
+import {merge} from 'ramda';
 import uuid from 'uuid';
 
 import {saveConnection} from '../../backend/persistent/Connections.js';
@@ -159,8 +159,17 @@ describe('Routes:', () => {
             return POST('queries', queryObject)
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then((json) => {
-                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
-                    assert.equal(json.uids.length, 6);
+                    assert.deepEqual(json, {
+                      ...queryObject,
+                      uids: [
+                        '08bd63',
+                        '3430b2',
+                        '618517',
+                        '812006',
+                        '3c7496',
+                        'b6b0bb'
+                      ]
+                    });
                     return GET('queries').then(getResponseJson)
                       .then((getResponse) => {
                         assert.deepEqual(getResponse, [json]);
@@ -243,12 +252,32 @@ describe('Routes:', () => {
                 })
                 .then(assertResponseStatus(201))
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                    assert.deepEqual(json, {
+                      ...queryObject,
+                      uids: [
+                        '9bbb87',
+                        '8d4dd0',
+                        '3e40ef',
+                        'b169c0',
+                        '55e326',
+                        'e69f70'
+                      ]
+                    });
                     return GET(`queries/${queryObject.fid}`);
                 })
                 .then(assertResponseStatus(200))
                 .then(getResponseJson).then(json => {
-                    assert.deepEqual(omit('uids', json), omit('uids', queryObject));
+                    assert.deepEqual(json, {
+                      ...queryObject,
+                      uids: [
+                        '9bbb87',
+                        '8d4dd0',
+                        '3e40ef',
+                        'b169c0',
+                        '55e326',
+                        'e69f70'
+                      ]
+                    });
                 });
         });
 

--- a/test/backend/routes.queries.spec.js
+++ b/test/backend/routes.queries.spec.js
@@ -114,18 +114,18 @@ describe('Routes:', () => {
                         query: 'SELECT * from ebola_2014 LIMIT 2'
                     };
 
-                    return POST('queries', queryObject)
-                    .then(assertResponseStatus(201))
-                    .then(getResponseJson).then(json2 => {
-                        assert.deepEqual(json2, queryObject);
+                    return POST('queries', queryObject);
+                })
+                .then(assertResponseStatus(201))
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(json, queryObject);
 
-                        return GET('queries');
-                    })
-                    .then(getResponseJson).then(json3 => {
-                        assert.deepEqual(json3, [queryObject]);
+                    return GET('queries');
+                })
+                .then(getResponseJson).then(json => {
+                    assert.deepEqual(json, [queryObject]);
 
-                        return deleteGrid(fid, username);
-                    });
+                    return deleteGrid(fid, username);
                 });
         });
 


### PR DESCRIPTION
@nicolaskruchten @n-riesco I'm still doing some manual testing, but I wanted to get this in front of you for review since I don't foresee the crux of it changing much.

### Overview

This PR makes a core change to the way grids are updated in Falcon. Because of how central an alteration this is, I'm going to go into some detail about how it's implemented to try and catch any misunderstandings or issues up front! Please let me know if any of this sounds incorrect or contrary to your understanding 🙂

Previous to this PR, the update functionality worked as follows:
- column `uid`'s are passed in as a parameter to `POST /queries`
- after running the supplied query, the `updateGrid` function is called which writes up to `uids.length` columns of data
- column names are never altered

This is problematic because it relies on clients (Chart Studio, Falcon scheduling UI) to handle column renaming, appending, and deleting by manually updating the grid themselves. The Falcon scheduling UI isn't doing any of this which is what led to the problems in #507. Chart Studio does handle these updates, but only if the query is rerun before syncing with Falcon.

To eliminate this reliance, the PR expands the update grid functionality to take care of these operations. The algorithm it uses mimics the requests used in Chart Studio which seems to optimize for preserving `uid`'s where possible (which is sensible since charts rely upon these)

After this PR, the update functionality works as follows:
- after running the supplied query, format the column data to explicitly set column names and ordering
- directly fetch the latest version of the grid and grab the `uid`s 
- if there are now more columns than `uid`s, update the existing columns in place and append any additional ones required
- if there are now fewer columns than `uid`s, delete surplus columns and update the required existing columns in place
- otherwise the number of columns and `uid`s are equal and the existing columns can be updated in place as in the older version

### Backwards Compatibility

Though not used directly anymore, the latest `uid`s are still stored with scheduled queries to support Old Falcon loading New Falcon yaml files. In cases we've found where this PR breaks from existing functionality, it does so by providing more data, not less. Regardless, I want to confirm the two main ones we're aware of aren't an issue:
- updates via `POST /queries` now respond with the updated scheduled query rather than returning an empty object
- requests which pass an outdated number of `uid`s (with respect to the number of columns returned in the current query) will still set the correct number of columns. For example, previously if in Chart Studio you had an existing single columned query (`select a`) and updated it to a multi columned query (`select a, b`) and hit _sync with connector_ before rerunning the query, the grid would incorrectly update with only one column whereas now it will populate both

closes #507 