### PR TITLE
settings: add variable PLOTLY_CONNECTOR_BASE_URL

### DIFF
--- a/backend/persistent/QueryScheduler.js
+++ b/backend/persistent/QueryScheduler.js
@@ -221,7 +221,7 @@ class QueryScheduler {
                     metadata: {
                         query,
                         connectionId,
-                        connectorUrl: `https://${getSetting('CONNECTOR_HTTPS_DOMAIN')}:${getSetting('PORT_HTTPS')}`
+                        connectorUrl: getSetting('BASE_URL')
                     },
                     refresh_interval: formattedRefresh
                 }
@@ -377,7 +377,7 @@ class QueryScheduler {
                     metadata: {
                         query,
                         connectionId,
-                        connectorUrl: `https://${getSetting('CONNECTOR_HTTPS_DOMAIN')}:${getSetting('PORT_HTTPS')}`
+                        connectorUrl: getSetting('BASE_URL')
                     },
                     refresh_interval: formattedRefresh
                 }

--- a/backend/settings.js
+++ b/backend/settings.js
@@ -71,6 +71,7 @@ const DEFAULT_SETTINGS = {
 
 // Settings that depend on other settings are described here
 const derivedSettingsNames = [
+    'BASE_URL',
     'PLOTLY_API_URL',
     'PLOTLY_URL',
     'CONNECTIONS_PATH',
@@ -84,6 +85,11 @@ const derivedSettingsNames = [
 
 function getDerivedSetting(settingName) {
     switch (settingName) {
+        case 'BASE_URL':
+            return getSetting('IS_RUNNING_INSIDE_ON_PREM') ?
+                process.env.PLOTLY_CONNECTOR_BASE_URL :
+                `https://${getSetting('CONNECTOR_HTTPS_DOMAIN')}:${getSetting('PORT_HTTPS')}`;
+
         case 'PLOTLY_URL': {
             if (getSetting('PLOTLY_API_DOMAIN') ===
                 DEFAULT_SETTINGS.PLOTLY_API_DOMAIN) {


### PR DESCRIPTION
* Added env variable PLOTLY_CONNECTOR_BASE_URL so that it is possible to
  customise connectorURL when running inside on-prem.

Closes https://github.com/plotly/streambed/issues/11310

---

@nicolaskruchten @scjody 

I've tested the PR locally:
- running as a desktop app: `yarn start`
- and simulating running inside on-prem by setting: `PLOTLY_CONNECTOR_BASE_URL="https://test/external-data-connector" PLOTLY_CONNECTOR_RUNNING_INSIDE_ON_PREM=true yarn start`